### PR TITLE
feat: Monthly Summary Pagination & Filtering

### DIFF
--- a/app/public/openapi.yaml
+++ b/app/public/openapi.yaml
@@ -226,28 +226,60 @@ paths:
             enum: [description, last4digits]
         - name: excludeBankTransactions
           in: query
-          description: Exclude bank transactions (category = 'Bank') from results. Only applicable when groupBy is 'description'. In the UI, bank transactions are excluded by default unless the user enables "Show Bank Transactions".
+          description: When true, filters out transactions originating from known bank vendors (e.g. hapoalim, leumi). Useful for isolating card-only expenses.
           schema:
             type: boolean
             default: false
+        - name: sortBy
+          in: query
+          description: Field to sort by
+          schema:
+            type: string
+            enum: [name, count, card_expenses]
+            default: card_expenses
+        - name: sortOrder
+          in: query
+          description: Sort direction
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
+        - name: limit
+          in: query
+          description: Maximum number of results
+          schema:
+            type: integer
+            default: 50
+        - name: offset
+          in: query
+          description: Pagination offset
+          schema:
+            type: integer
+            default: 0
       responses:
         '200':
           description: Monthly summary data
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    bank_income:
-                      type: number
-                    bank_expenses:
-                      type: number
-                    card_expenses:
-                      type: number
-                    net_balance:
-                      type: number
+                type: object
+                properties:
+                  total:
+                    type: integer
+                    description: Total number of items matching the filter
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        bank_income:
+                          type: number
+                        bank_expenses:
+                          type: number
+                        card_expenses:
+                          type: number
+                        net_balance:
+                          type: number
 
   /reports/budget-vs-actual:
     get:

--- a/app/tests/encryption.test.ts
+++ b/app/tests/encryption.test.ts
@@ -1,9 +1,17 @@
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import crypto from 'crypto';
 import { encrypt, decrypt } from '../pages/api/utils/encryption';
 
 describe('Encryption Utility Security', () => {
+    // Set a valid 32-byte hex key for testing
+    // 32 bytes = 64 hex characters
+    const MOCK_KEY = 'a'.repeat(64);
+
+    beforeEach(() => {
+        process.env.ENCRYPTION_KEY = MOCK_KEY;
+    });
+
     const testData = 'SensitivePassword123!';
 
     it('should encrypt and decrypt data correctly', () => {

--- a/app/tests/monthly_summary_api.test.ts
+++ b/app/tests/monthly_summary_api.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getDB } from '../pages/api/db';
+import handler from '../pages/api/reports/monthly-summary';
+
+// Mock the database module
+vi.mock('../pages/api/db', () => ({
+    getDB: vi.fn(),
+    pool: {
+        connect: vi.fn(),
+        query: vi.fn(),
+        on: vi.fn(),
+    }
+}));
+
+// Mock the logger
+vi.mock('../utils/logger.js', () => ({
+    default: {
+        info: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn()
+    }
+}));
+
+// Mock the transaction_logic
+vi.mock('../utils/transaction_logic', () => ({
+    getBillingCycleSql: vi.fn(() => 'mock_billing_sql')
+}));
+
+describe('Monthly Summary API Endpoint', () => {
+    let mockClient: {
+        query: ReturnType<typeof vi.fn>;
+        release: ReturnType<typeof vi.fn>;
+    };
+    let mockReq: any;
+    let mockRes: {
+        status: ReturnType<typeof vi.fn>;
+        json: ReturnType<typeof vi.fn>;
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        mockClient = {
+            query: vi.fn(),
+            release: vi.fn()
+        };
+
+        (getDB as ReturnType<typeof vi.fn>).mockResolvedValue(mockClient);
+
+        mockRes = {
+            status: vi.fn().mockReturnThis(),
+            json: vi.fn().mockReturnThis()
+        };
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('Bank Transactions Filtering', () => {
+        it('should exclude bank transactions when excludeBankTransactions is true', async () => {
+            mockReq = {
+                method: 'GET',
+                query: {
+                    startDate: '2023-01-01',
+                    endDate: '2023-01-31',
+                    groupBy: 'description',
+                    excludeBankTransactions: 'true'
+                }
+            };
+
+            mockClient.query.mockResolvedValue({
+                rowCount: 0,
+                rows: []
+            });
+
+            await handler(mockReq, mockRes);
+
+            expect(mockClient.query).toHaveBeenCalledTimes(1);
+            const [sql] = mockClient.query.mock.calls[0];
+
+            // Should exclude bank vendors
+            expect(sql).toContain('t.vendor NOT IN');
+            expect(sql).toContain('\'hapoalim\'');
+            expect(sql).toContain('\'leumi\'');
+
+            // IMPORTANT: Should NOT contain category filtering (user requirement)
+            expect(sql).not.toContain('category NOT IN');
+            expect(sql).not.toContain('\'Mortgage\'');
+            expect(sql).not.toContain('\'משכנתא\'');
+        });
+
+        it('should NOT exclude bank transactions when excludeBankTransactions is false', async () => {
+            mockReq = {
+                method: 'GET',
+                query: {
+                    startDate: '2023-01-01',
+                    endDate: '2023-01-31',
+                    groupBy: 'description',
+                    excludeBankTransactions: 'false'
+                }
+            };
+
+            mockClient.query.mockResolvedValue({
+                rowCount: 0,
+                rows: []
+            });
+
+            await handler(mockReq, mockRes);
+
+            const [sql] = mockClient.query.mock.calls[0];
+
+            expect(sql).not.toContain('t.vendor NOT IN (\'hapoalim\'');
+        });
+    });
+
+    describe('Pagination', () => {
+        it('should include LIMIT and OFFSET in the SQL with default values', async () => {
+            mockReq = {
+                method: 'GET',
+                query: {
+                    startDate: '2023-01-01',
+                    endDate: '2023-01-31',
+                    groupBy: 'description'
+                }
+            };
+
+            mockClient.query.mockResolvedValue({
+                rowCount: 0,
+                rows: []
+            });
+
+            await handler(mockReq, mockRes);
+
+            const [sql, params] = mockClient.query.mock.calls[0];
+            // StartDate/EndDate are $1/$2, so LIMIT/OFFSET are $3/$4
+            expect(sql).toContain('ORDER BY ABS(COALESCE(SUM(t.price), 0)) DESC, t.name ASC');
+            expect(sql).toContain('LIMIT $3 OFFSET $4');
+            expect(params).toContain(50);
+            expect(params).toContain(0);
+        });
+
+        it('should use provided limit and offset values', async () => {
+            mockReq = {
+                method: 'GET',
+                query: {
+                    startDate: '2023-01-01',
+                    endDate: '2023-01-31',
+                    groupBy: 'description',
+                    limit: '20',
+                    offset: '40'
+                }
+            };
+
+            mockClient.query.mockResolvedValue({
+                rowCount: 1,
+                rows: [{ description: 'Test', total_count: 100 }]
+            });
+
+            await handler(mockReq, mockRes);
+
+            const [sql, params] = mockClient.query.mock.calls[0];
+            expect(sql).toContain('LIMIT $3 OFFSET $4');
+            expect(params).toContain(20);
+            expect(params).toContain(40);
+
+            // Verify response format
+            expect(mockRes.json).toHaveBeenCalledWith({
+                items: [{ description: 'Test' }],
+                total: 100
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Motivation
The monthly summary report needed performance improvements to handle large numbers of transactions efficiently. Additionally, the existing "bank transaction" filtering was too aggressive, hiding valid credit card transactions based on generic categories.

## Description
This PR implements server-side pagination and sorting to ensure snappy performance and accurate data representation.

**Key Changes:**
*   **API**:
    *   Added `limit`, `offset`, `sortBy`, and `sortOrder` parameters.
    *   Implemented stable server-side sorting with tie-breakers.
    *   Changed exclusion logic to filter only by **Vendor** (e.g., Hapoalim), ignoring categories.
    *   Response format updated to `{ items, total }`.
*   **UI**:
    *   Added "Load More" button for incremental loading.
    *   Added sortable headers (Name, Count, Amount).
    *   Fixed sidebar visibility bug when filtering the main table.
*   **Docs**: Updated `openapi.yaml`.
*   **Tests**: Added unit tests for pagination, sorting defaults, and filtering logic.

## Architecture
*   **Backend**: SQL queries now dynamically generate `ORDER BY` clauses and use `OFFSET/LIMIT`. Window functions calculate total counts without a second query.
*   **Frontend**: State management updated to handle incremental data fetching.