### PR TITLE
feat: support nested installments and automatic updates on rescrape

### DIFF
--- a/app/tests/installments.test.ts
+++ b/app/tests/installments.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { insertTransaction } from '../pages/api/utils/scraperUtils';
+
+// Mock the database module
+vi.mock('../pages/api/db', () => ({
+    getDB: vi.fn()
+}));
+
+// Mock the logger
+vi.mock('../utils/logger.js', () => ({
+    default: {
+        info: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn()
+    }
+}));
+
+// Mock transactionUtils
+vi.mock('../pages/api/utils/transactionUtils.js', () => ({
+    generateTransactionIdentifier: vi.fn().mockReturnValue('mock-tx-id')
+}));
+
+describe('Installments Support', () => {
+    let mockClient: any;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockClient = {
+            query: vi.fn().mockResolvedValue({ rows: [] })
+        };
+    });
+
+    it('should correctly extract installments from top-level properties', async () => {
+        const transaction = {
+            date: '2023-01-01',
+            description: 'Test Installment',
+            originalAmount: 1000,
+            chargedAmount: 100,
+            installmentsNumber: 1,
+            installmentsTotal: 10,
+            status: 'completed',
+            identifier: 'tx1'
+        };
+
+        await insertTransaction(mockClient, transaction, 'max', '1234', 'ILS');
+
+        const insertCall = mockClient.query.mock.calls.find(call =>
+            call[0].includes('INSERT INTO transactions')
+        );
+
+        expect(insertCall).toBeDefined();
+        const params = insertCall[1];
+        // installments_number is index 13 ($14)
+        // installments_total is index 14 ($15)
+        expect(params[13]).toBe(1);
+        expect(params[14]).toBe(10);
+    });
+
+    it('should correctly extract installments from nested installments object (israeli-bank-scrapers format)', async () => {
+        const transaction = {
+            date: '2023-01-01',
+            description: 'Test Installment',
+            originalAmount: 1000,
+            chargedAmount: 100,
+            installments: {
+                number: 2,
+                total: 10
+            },
+            status: 'completed',
+            identifier: 'tx2'
+        };
+
+        await insertTransaction(mockClient, transaction, 'max', '1234', 'ILS');
+
+        const insertCall = mockClient.query.mock.calls.find(call =>
+            call[0].includes('INSERT INTO transactions')
+        );
+
+        expect(insertCall).toBeDefined();
+        const params = insertCall[1];
+        expect(params[13]).toBe(2);
+        expect(params[14]).toBe(10);
+    });
+
+    it('should handle missing installment data', async () => {
+        const transaction = {
+            date: '2023-01-01',
+            description: 'Regular Transaction',
+            originalAmount: 100,
+            chargedAmount: 100,
+            status: 'completed',
+            identifier: 'tx3'
+        };
+
+        await insertTransaction(mockClient, transaction, 'max', '1234', 'ILS');
+
+        const insertCall = mockClient.query.mock.calls.find((call: any) =>
+            call[0].includes('INSERT INTO transactions')
+        );
+
+        expect(insertCall).toBeDefined();
+        const params = insertCall[1];
+        expect(params[13]).toBeNull();
+        expect(params[14]).toBeNull();
+    });
+
+    it('should update installments if existing transaction has no installments', async () => {
+        // Mock existing transaction with null installments
+        mockClient.query.mockResolvedValueOnce({
+            rows: [{
+                identifier: 'tx4',
+                name: 'Test Update',
+                price: 100,
+                date: new Date('2023-01-01'),
+                category: 'Food',
+                category_source: 'scraper',
+                installments_number: null,
+                installments_total: null
+            }]
+        });
+
+        const transaction = {
+            date: '2023-01-01',
+            description: 'Test Update',
+            originalAmount: 100,
+            chargedAmount: 100,
+            installments: {
+                number: 1,
+                total: 5
+            },
+            status: 'completed',
+            identifier: 'tx4'
+        };
+
+        const result = await insertTransaction(mockClient, transaction, 'max', '1234', 'ILS');
+
+        expect(result.updated).toBe(true);
+        const updateCall = mockClient.query.mock.calls.find((call: any) =>
+            call[0].includes('UPDATE transactions SET') && call[0].includes('installments_number')
+        );
+
+        expect(updateCall).toBeDefined();
+        expect(updateCall[1]).toContain(1);
+        expect(updateCall[1]).toContain(5);
+    });
+
+    it('should update installments via business key logic if missing', async () => {
+        // First query (identifier) -> empty
+        mockClient.query.mockResolvedValueOnce({ rows: [] });
+        // Second query (business key) -> match with no installments
+        mockClient.query.mockResolvedValueOnce({
+            rows: [{
+                identifier: 'old-id',
+                category: 'Food',
+                category_source: 'scraper',
+                installments_total: null
+            }]
+        });
+
+        const transaction = {
+            date: '2023-01-01',
+            description: 'Business Key Match',
+            originalAmount: 200,
+            chargedAmount: 200,
+            installments: {
+                number: 1,
+                total: 3
+            },
+            status: 'completed'
+        };
+
+        const result = await insertTransaction(mockClient, transaction, 'max', '1234', 'ILS');
+
+        expect(result.updated).toBe(true);
+        const updateCall = mockClient.query.mock.calls.find((call: any) =>
+            call[0].includes('UPDATE transactions SET') && call[0].includes('installments_number')
+        );
+
+        expect(updateCall).toBeDefined();
+        expect(updateCall[1]).toContain(1);
+        expect(updateCall[1]).toContain(3);
+    });
+});


### PR DESCRIPTION
## Motivation
Existing scraped transactions often lack installment metadata (e.g., total number of installments) if they are scraped on the same day the purchase was made but before the processor has fully "booked" the installment schedule. This leads to a persistent lack of metadata even after subsequent scrapes. Additionally, the `israeli-bank-scrapers` library often provides installments in a nested object (`transaction.installments.total`), which wasn't fully supported in our flat extraction logic.

## Description
- **Extended Extraction**: Modified `insertTransaction` to support extraction from both top-level fields (`installmentsNumber`) and nested `installments` objects (`installments.number`).
- **Smart Updates**: Added logic to update `installments_number` and `installments_total` for existing transactions if the newly scraped data contains more complete information (e.g., DB has null/1 but scraper has 5).
- **Cache Optimization**: Updated `fetchHistoryCache` to include installment fields in the deduplication cache, reducing DB round-trips for batch updates.
- **Testing**: Added `app/tests/installments.test.ts` covering:
  - Top-level property extraction.
  - Nested object extraction.
  - Automatic updates for existing transactions.
  - Business key matching and updating.

## Architecture
- The `scraperUtils.js` module implements an idempotent "Upsert" logic for transactions.
- The logic flow is:
  1. Determine Category (Rule -> Cache -> Scraper).
  2. Identifier Match: If found, check for "Collision" (consistency check). If consistent, check for "Updateable" fields (Category if enabled, and now Installments).
  3. Business Key Match (Date + Name + Price): Same logic as above but for transactions that may have changed identifiers.
  4. Final Insert (Atomic ON CONFLICT DO NOTHING).
- The history cache is used as a first-pass in-memory filter to optimize performance during high-volume scrapes.

---
Tested locally with `npx vitest tests/installments.test.ts` - 5/5 passed.