### PR TITLE
feat: add installments info to scrape report

### DIFF
--- a/app/components/ScrapeReport.tsx
+++ b/app/components/ScrapeReport.tsx
@@ -26,6 +26,9 @@ export interface ScrapeReportTransaction {
     isDuplicate?: boolean;
     source?: string;
     rule?: string;
+    installmentsNumber?: number;
+    installmentsTotal?: number;
+    totalAmount?: number;
 }
 
 export interface ScrapeReportSummary {
@@ -174,6 +177,7 @@ export default function ScrapeReport({ report, summary }: ScrapeReportProps) {
             <th style={{ padding: '10px 12px', fontWeight: 600, width: '120px', textAlign: 'left', borderBottom: `1px solid ${theme.palette.divider}` }}>Account</th>
             <th style={{ padding: '10px 12px', fontWeight: 600, width: '200px', textAlign: 'left', borderBottom: `1px solid ${theme.palette.divider}` }}>Description</th>
             <th style={{ padding: '10px 12px', fontWeight: 600, textAlign: 'right', width: '100px', borderBottom: `1px solid ${theme.palette.divider}` }}>Amount</th>
+            <th style={{ padding: '10px 12px', fontWeight: 600, width: '100px', textAlign: 'center', borderBottom: `1px solid ${theme.palette.divider}` }}>Installments</th>
             <th style={{ padding: '10px 12px', fontWeight: 600, width: '150px', textAlign: 'left', borderBottom: `1px solid ${theme.palette.divider}` }}>Category</th>
             <th style={{ padding: '10px 12px', fontWeight: 600, width: '100px', textAlign: 'left', borderBottom: `1px solid ${theme.palette.divider}` }}>Status</th>
         </tr>
@@ -211,6 +215,30 @@ export default function ScrapeReport({ report, summary }: ScrapeReportProps) {
                 }}>
                     {Math.abs(tx.amount).toFixed(2)}
                 </Typography>
+            </td>
+            <td style={{ padding: '6px 12px', textAlign: 'center', whiteSpace: 'nowrap' }}>
+                {tx.installmentsTotal && tx.installmentsTotal > 1 ? (
+                    <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                        <Typography variant="caption" sx={{
+                            color: theme.palette.text.secondary,
+                            bgcolor: theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.05)' : '#f3f4f6',
+                            px: 1,
+                            py: 0.25,
+                            borderRadius: 1,
+                            fontWeight: 600,
+                            border: `1px solid ${theme.palette.divider}`
+                        }}>
+                            {tx.installmentsNumber} / {tx.installmentsTotal}
+                        </Typography>
+                        {tx.totalAmount && Math.abs(tx.totalAmount) !== Math.abs(tx.amount) && (
+                            <Typography variant="caption" sx={{ color: 'text.disabled', fontSize: '0.65rem', mt: 0.5 }}>
+                                of {Math.abs(tx.totalAmount).toFixed(0)}
+                            </Typography>
+                        )}
+                    </Box>
+                ) : (
+                    <Typography variant="caption" sx={{ color: 'text.disabled' }}>-</Typography>
+                )}
             </td>
             <td style={{ padding: '6px 12px' }}>
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>

--- a/app/pages/api/utils/scraperUtils.js
+++ b/app/pages/api/utils/scraperUtils.js
@@ -1185,7 +1185,10 @@ export async function processScrapedAccounts({
           isUpdate: !!insertResult.updated,
           isDuplicate: !!insertResult.duplicated && !insertResult.updated,
           isBank: isBank,
-          oldCategory: insertResult.oldCategory
+          oldCategory: insertResult.oldCategory,
+          installmentsNumber: txn.installmentsNumber || txn.installments?.number,
+          installmentsTotal: txn.installmentsTotal || txn.installments?.total,
+          totalAmount: txn.originalAmount
         };
 
         if (insertResult.updated) {

--- a/app/public/openapi.yaml
+++ b/app/public/openapi.yaml
@@ -1607,7 +1607,39 @@ components:
         processedTransactions:
           type: array
           items:
-            $ref: '#/components/schemas/Transaction'
+            type: object
+            properties:
+              date:
+                type: string
+                format: date
+              description:
+                type: string
+              amount:
+                type: number
+              currency:
+                type: string
+              category:
+                type: string
+              source:
+                type: string
+              rule:
+                type: string
+              cardLast4:
+                type: string
+              isUpdate:
+                type: boolean
+              isDuplicate:
+                type: boolean
+              isBank:
+                type: boolean
+              oldCategory:
+                type: string
+              installmentsNumber:
+                type: integer
+              installmentsTotal:
+                type: integer
+              totalAmount:
+                type: number
         savedTransactions:
           type: integer
         duration_seconds:

--- a/app/tests/scrape_report_installments.test.ts
+++ b/app/tests/scrape_report_installments.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { processScrapedAccounts } from '../pages/api/utils/scraperUtils';
+
+// Mock the database module
+vi.mock('../pages/api/db', () => ({
+    getDB: vi.fn()
+}));
+
+// Mock the logger
+vi.mock('../utils/logger.js', () => ({
+    default: {
+        info: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn()
+    }
+}));
+
+// Mock transactionUtils
+vi.mock('../pages/api/utils/transactionUtils.js', () => ({
+    generateTransactionIdentifier: vi.fn().mockReturnValue('mock-tx-id')
+}));
+
+describe('Scrape Report Installments', () => {
+    let mockClient: any;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockClient = {
+            query: vi.fn().mockResolvedValue({ rows: [] }),
+            release: vi.fn()
+        };
+    });
+
+    it('should include installment information in processedTransactions report items', async () => {
+        const accounts = [
+            {
+                accountNumber: '1234',
+                txns: [
+                    {
+                        date: '2023-01-01',
+                        description: 'Installment Purchase',
+                        originalAmount: 1200,
+                        chargedAmount: 100,
+                        installments: {
+                            number: 3,
+                            total: 12
+                        },
+                        status: 'completed',
+                        identifier: 'tx1'
+                    }
+                ]
+            }
+        ];
+
+        // Mock history fetch
+        mockClient.query.mockResolvedValueOnce({ rows: [] }); // category_categories check
+        mockClient.query.mockResolvedValueOnce({ rows: [] }); // history fetch
+        mockClient.query.mockResolvedValueOnce({ rows: [] }); // transaction BEGIN
+        mockClient.query.mockResolvedValueOnce({ rows: [] }); // checkCardOwnership
+        mockClient.query.mockResolvedValueOnce({ rows: [] }); // claimCardOwnership
+        mockClient.query.mockResolvedValueOnce({ rows: [] }); // insertTransaction - identifier check
+        mockClient.query.mockResolvedValueOnce({ rows: [] }); // insertTransaction - business key check
+        mockClient.query.mockResolvedValueOnce({ rows: [] }); // insertTransaction - INSERT
+        mockClient.query.mockResolvedValueOnce({ rows: [] }); // transaction COMMIT
+
+        const stats = await processScrapedAccounts({
+            client: mockClient,
+            accounts,
+            companyId: 'max',
+            credentialId: 1,
+            categorizationRules: [],
+            categoryMappings: {},
+            billingCycleStartDay: 10,
+            updateCategoryOnRescrape: false,
+            isBank: false
+        });
+
+        expect(stats.processedTransactions.length).toBe(1);
+        const item = stats.processedTransactions[0];
+        expect(item.installmentsNumber).toBe(3);
+        expect(item.installmentsTotal).toBe(12);
+        expect(item.totalAmount).toBe(1200);
+        expect(item.amount).toBe(100);
+    });
+});


### PR DESCRIPTION
## Motivation
Provide users with more visibility into installment transactions (current/total installments and total transaction amount) directly in the scrape report after a sync process. This helps in verifying that installments were correctly identified and recorded.

## Description
This PR updates the scraper utility and the frontend reporting component to handle and display installment-related information. 

Key changes:
- Updated the backend reporting logic to include installment numbers and total amounts in the scrape summary.
- Added an "Installments" column to the `ScrapeReport` UI.
- Updated the OpenAPI specification to reflect the new fields in the scrape report API.
- Added a unit test to ensure data integrity during the reporting phase.

## Archticture
- **Backend**: `processScrapedAccounts` in `scraperUtils.js` was modified to extract `installmentsNumber`, `installmentsTotal`, and `totalAmount` from the transaction object and include them in each `reportItem`.
- **API**: The `ScrapeReport` schema in `openapi.yaml` was updated to explicitly define these new fields, ensuring type safety and documentation accuracy.
- **Frontend**: The `ScrapeReport.tsx` component was updated to include a new table column. It uses a clean UI with badges for installment progress and subtle text for total amounts.
- **Testing**: A new test file `app/tests/scrape_report_installments.test.ts` covers the mapping logic in `processScrapedAccounts`.