### PR TITLE
fix: improve database connection resilience to prevent timeouts

### DIFF
--- a/app/pages/api/db.js
+++ b/app/pages/api/db.js
@@ -11,15 +11,51 @@ export const pool = new Pool({
   // Optimization for Docker/Low Resource environments
   max: process.env.LOW_RESOURCES_MODE === 'true' ? 5 : 20,
   idleTimeoutMillis: 30000,
-  connectionTimeoutMillis: 5000,
+  connectionTimeoutMillis: 10000,
+  // Keepalive settings to prevent idle connections from being terminated
+  keepAlive: true,
+  keepAliveInitialDelayMillis: 10000,
+  // Allow proper cleanup when the application exits
+  allowExitOnIdle: true,
+});
+
+// Handle pool-level errors to prevent unhandled exceptions
+pool.on('error', (err, client) => {
+  logger.error({ error: err.message, stack: err.stack }, "Unexpected error on idle database client");
+});
+
+// Log when connections are acquired and released (debug level)
+pool.on('connect', (client) => {
+  logger.debug("New database connection established");
+});
+
+pool.on('remove', (client) => {
+  logger.debug("Database connection removed from pool");
 });
 
 export async function getDB() {
-  try {
-    const client = await pool.connect();
-    return client;
-  } catch (error) {
-    logger.error({ error: error.message, stack: error.stack }, "Error connecting to the database");
-    throw new Error("Database connection failed");
+  const maxRetries = 3;
+  let lastError;
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      const client = await pool.connect();
+      return client;
+    } catch (error) {
+      lastError = error;
+      logger.warn({
+        error: error.message,
+        attempt,
+        maxRetries
+      }, "Database connection attempt failed");
+
+      if (attempt < maxRetries) {
+        // Wait before retrying (exponential backoff: 1s, 2s)
+        await new Promise(resolve => setTimeout(resolve, attempt * 1000));
+      }
+    }
   }
+
+  logger.error({ error: lastError.message, stack: lastError.stack }, "Error connecting to the database after all retries");
+  throw new Error("Database connection failed");
 }


### PR DESCRIPTION
- Increase connectionTimeoutMillis from 5s to 10s for containerized environments
- Add keepAlive and keepAliveInitialDelayMillis to prevent idle connection termination
- Add pool-level error event handlers to prevent unhandled exceptions
- Implement retry logic with exponential backoff (3 attempts) in getDB()
- Add debug logging for connection lifecycle events
- Add allowExitOnIdle for proper cleanup on application exit