### PR TITLE
Add WhatsApp QR code renewal feature

### DIFF
--- a/app/components/SettingsModal.tsx
+++ b/app/components/SettingsModal.tsx
@@ -273,11 +273,11 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
     return () => clearInterval(interval);
   }, [open, whatsappStatus.status]);
 
-  const handleWhatsAppAction = async (action: 'connect' | 'restart' | 'disconnect') => {
+  const handleWhatsAppAction = async (action: 'connect' | 'restart' | 'disconnect' | 'renewQr') => {
     try {
       // Optimistic update
-      if (action === 'connect' || action === 'restart') {
-        setWhatsappStatus(prev => ({ ...prev, status: 'INITIALIZING' }));
+      if (action === 'connect' || action === 'restart' || action === 'renewQr') {
+        setWhatsappStatus(prev => ({ ...prev, status: 'INITIALIZING', qr: null }));
       }
 
       await fetch('/api/whatsapp/status', {
@@ -896,14 +896,35 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
 
               {/* Connected Controls */}
               {(whatsappStatus.status === 'READY' || whatsappStatus.status === 'AUTHENTICATED') && (
-                <Box sx={{ mb: 3, display: 'flex', justifyContent: 'center' }}>
-                  <Button
-                    size="small"
-                    color="error"
-                    onClick={() => handleWhatsAppAction('disconnect')}
-                  >
-                    Disconnect Session
-                  </Button>
+                <Box sx={{ mb: 3, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
+                  <Box sx={{ display: 'flex', gap: 2 }}>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      onClick={() => handleWhatsAppAction('renewQr')}
+                      startIcon={<SyncIcon />}
+                      sx={{
+                        borderColor: '#f59e0b',
+                        color: '#f59e0b',
+                        '&:hover': {
+                          borderColor: '#d97706',
+                          backgroundColor: 'rgba(245, 158, 11, 0.1)',
+                        },
+                      }}
+                    >
+                      Renew QR Code
+                    </Button>
+                    <Button
+                      size="small"
+                      color="error"
+                      onClick={() => handleWhatsAppAction('disconnect')}
+                    >
+                      Disconnect Session
+                    </Button>
+                  </Box>
+                  <Typography variant="caption" sx={{ color: theme.palette.text.secondary, textAlign: 'center' }}>
+                    Renew QR to link a different WhatsApp account or fix connection issues
+                  </Typography>
                 </Box>
               )}
 

--- a/app/pages/api/whatsapp/status.js
+++ b/app/pages/api/whatsapp/status.js
@@ -1,5 +1,5 @@
 
-import { getStatus, restartClient, destroyClient, initializeClient } from '../../../utils/whatsapp-client.js';
+import { getStatus, restartClient, destroyClient, initializeClient, renewQrCode } from '../../../utils/whatsapp-client.js';
 
 export default async function handler(req, res) {
     if (req.method === 'GET') {
@@ -24,6 +24,12 @@ export default async function handler(req, res) {
         if (action === 'disconnect') {
             await destroyClient();
             return res.status(200).json({ message: 'Client disconnected' });
+        }
+
+        if (action === 'renewQr') {
+            // Renew QR code by clearing session and reinitializing
+            renewQrCode();
+            return res.status(200).json({ message: 'Renewing QR code... New QR will be generated shortly.' });
         }
 
         return res.status(400).json({ error: 'Invalid action' });

--- a/app/tests/whatsapp-status-api.test.ts
+++ b/app/tests/whatsapp-status-api.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import handler from '../pages/api/whatsapp/status.js';
+
+// Mock the whatsapp-client module
+vi.mock('../utils/whatsapp-client.js', () => ({
+    getStatus: vi.fn().mockReturnValue({
+        status: 'DISCONNECTED',
+        qr: null,
+        timestamp: new Date().toISOString()
+    }),
+    restartClient: vi.fn().mockResolvedValue(undefined),
+    destroyClient: vi.fn().mockResolvedValue(undefined),
+    initializeClient: vi.fn(),
+    renewQrCode: vi.fn(),
+}));
+
+import { getStatus, restartClient, destroyClient, initializeClient, renewQrCode } from '../utils/whatsapp-client.js';
+
+// Helper to create mock req/res
+function createMockReqRes(method: string, body?: object) {
+    const req = {
+        method,
+        body: body || {},
+    };
+    const res = {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn().mockReturnThis(),
+    };
+    return { req, res };
+}
+
+describe('WhatsApp Status API', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('GET /api/whatsapp/status', () => {
+        it('should return current status', async () => {
+            const { req, res } = createMockReqRes('GET');
+
+            await handler(req as any, res as any);
+
+            expect(getStatus).toHaveBeenCalled();
+            expect(res.status).toHaveBeenCalledWith(200);
+            expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+                status: 'DISCONNECTED',
+                qr: null,
+            }));
+        });
+    });
+
+    describe('POST /api/whatsapp/status', () => {
+        it('should handle connect action', async () => {
+            const { req, res } = createMockReqRes('POST', { action: 'connect' });
+
+            await handler(req as any, res as any);
+
+            expect(initializeClient).toHaveBeenCalled();
+            expect(res.status).toHaveBeenCalledWith(200);
+            expect(res.json).toHaveBeenCalledWith({ message: 'Connecting... QR code will be generated shortly.' });
+        });
+
+        it('should handle restart action', async () => {
+            const { req, res } = createMockReqRes('POST', { action: 'restart' });
+
+            await handler(req as any, res as any);
+
+            expect(restartClient).toHaveBeenCalled();
+            expect(res.status).toHaveBeenCalledWith(200);
+            expect(res.json).toHaveBeenCalledWith({ message: 'Restarting client...' });
+        });
+
+        it('should handle disconnect action', async () => {
+            const { req, res } = createMockReqRes('POST', { action: 'disconnect' });
+
+            await handler(req as any, res as any);
+
+            expect(destroyClient).toHaveBeenCalled();
+            expect(res.status).toHaveBeenCalledWith(200);
+            expect(res.json).toHaveBeenCalledWith({ message: 'Client disconnected' });
+        });
+
+        it('should handle renewQr action', async () => {
+            const { req, res } = createMockReqRes('POST', { action: 'renewQr' });
+
+            await handler(req as any, res as any);
+
+            expect(renewQrCode).toHaveBeenCalled();
+            expect(res.status).toHaveBeenCalledWith(200);
+            expect(res.json).toHaveBeenCalledWith({ message: 'Renewing QR code... New QR will be generated shortly.' });
+        });
+
+        it('should return 400 for invalid action', async () => {
+            const { req, res } = createMockReqRes('POST', { action: 'invalidAction' });
+
+            await handler(req as any, res as any);
+
+            expect(res.status).toHaveBeenCalledWith(400);
+            expect(res.json).toHaveBeenCalledWith({ error: 'Invalid action' });
+        });
+    });
+
+    describe('Other HTTP methods', () => {
+        it('should return 405 for unsupported methods', async () => {
+            const { req, res } = createMockReqRes('DELETE');
+
+            await handler(req as any, res as any);
+
+            expect(res.status).toHaveBeenCalledWith(405);
+            expect(res.json).toHaveBeenCalledWith({ error: 'Method not allowed' });
+        });
+    });
+});


### PR DESCRIPTION
Add the ability to renew the WhatsApp QR code from the settings screen.
This is useful when users want to link a different WhatsApp account or
fix connection issues without manually clearing session files.

- Add clearSession() and renewQrCode() functions to whatsapp-client.js
- Add renewQr action to POST /api/whatsapp/status endpoint
- Add Renew QR Code button in SettingsModal when WhatsApp is connected
- Add comprehensive tests for new functions and API endpoint