### PR TITLE
Fix Mobile Category Editing and Accessibility

### DIFF
--- a/app/components/CategoryDashboard/components/CategoryManagementModal.tsx
+++ b/app/components/CategoryDashboard/components/CategoryManagementModal.tsx
@@ -991,26 +991,32 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
                         }}
                       />
                       <IconButton
-                        size="small"
+                        size="medium"
                         onClick={(e) => openRenameDialog(category.name, e)}
-                        style={{
-                          padding: '4px',
-                          color: categoryColors[category.name] || '#3b82f6'
+                        sx={{
+                          padding: { xs: '8px', sm: '4px' },
+                          color: categoryColors[category.name] || '#3b82f6',
+                          '& .MuiSvgIcon-root': {
+                            fontSize: { xs: '20px', sm: '16px' }
+                          }
                         }}
                         title={`Rename "${category.name}"`}
                       >
-                        <EditIcon style={{ fontSize: '16px' }} />
+                        <EditIcon />
                       </IconButton>
                       <IconButton
-                        size="small"
+                        size="medium"
                         onClick={(e) => openDeleteDialog(category.name, e)}
-                        style={{
-                          padding: '4px',
-                          color: '#ef4444'
+                        sx={{
+                          padding: { xs: '8px', sm: '4px' },
+                          color: '#ef4444',
+                          '& .MuiSvgIcon-root': {
+                            fontSize: { xs: '20px', sm: '16px' }
+                          }
                         }}
                         title={`Delete "${category.name}"`}
                       >
-                        <DeleteIcon style={{ fontSize: '16px' }} />
+                        <DeleteIcon />
                       </IconButton>
                     </Box>
                   ))}
@@ -1139,15 +1145,27 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
                               />
                               <IconButton
                                 onClick={() => setEditingRule(rule)}
-                                size="small"
-                                style={{ color: '#3b82f6' }}
+                                size="medium"
+                                sx={{
+                                  padding: { xs: '8px', sm: '4px' },
+                                  color: '#3b82f6',
+                                  '& .MuiSvgIcon-root': {
+                                    fontSize: { xs: '20px', sm: '16px' }
+                                  }
+                                }}
                               >
                                 <EditIcon />
                               </IconButton>
                               <IconButton
                                 onClick={() => handleDeleteRule(rule.id)}
-                                size="small"
-                                style={{ color: '#ef4444' }}
+                                size="medium"
+                                sx={{
+                                  padding: { xs: '8px', sm: '4px' },
+                                  color: '#ef4444',
+                                  '& .MuiSvgIcon-root': {
+                                    fontSize: { xs: '20px', sm: '16px' }
+                                  }
+                                }}
                               >
                                 <DeleteIcon />
                               </IconButton>
@@ -1161,69 +1179,66 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
               )}
             </Box>
 
-            {editingRule && (
-              <Box style={{
-                position: 'fixed',
-                top: 0,
-                left: 0,
-                right: 0,
-                bottom: 0,
-                backgroundColor: 'rgba(0,0,0,0.5)',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                zIndex: 9999
-              }}>
-                <Card style={{
-                  padding: '24px',
-                  maxWidth: '500px',
+            <Dialog
+              open={Boolean(editingRule)}
+              onClose={() => setEditingRule(null)}
+              PaperProps={{
+                sx: {
+                  borderRadius: '16px',
+                  padding: '8px',
                   width: '100%',
-                  margin: '16px',
-                  backgroundColor: theme.palette.background.paper,
-                }}>
-                  <Typography variant="h6" style={{ marginBottom: '16px' }}>Edit Rule</Typography>
-                  <Grid container spacing={2} style={{ marginBottom: '16px' }}>
-                    <Grid item xs={6}>
-                      <TextField
-                        fullWidth
-                        label="Transaction Name Pattern"
-                        value={editingRule.name_pattern}
-                        onChange={(e) => setEditingRule({ ...editingRule, name_pattern: e.target.value })}
-                        disabled={isLoading}
-                      />
-                    </Grid>
-                    <Grid item xs={6}>
-                      <TextField
-                        fullWidth
-                        label="Target Category"
-                        value={editingRule.target_category}
-                        onChange={(e) => setEditingRule({ ...editingRule, target_category: e.target.value })}
-                        disabled={isLoading}
-                      />
-                    </Grid>
-                  </Grid>
-                  <Box display="flex" gap="8px" justifyContent="flex-end">
-                    <Button
-                      onClick={() => setEditingRule(null)}
-                      style={{ color: theme.palette.text.secondary }}
-                    >
-                      Cancel
-                    </Button>
-                    <Button
-                      variant="contained"
-                      onClick={() => handleUpdateRule(editingRule)}
+                  maxWidth: '500px'
+                }
+              }}
+            >
+              <DialogTitle sx={{ fontWeight: 700 }}>Edit Rule</DialogTitle>
+              <DialogContent>
+                <Grid container spacing={2} sx={{ mt: 1 }}>
+                  <Grid item xs={12} sm={6}>
+                    <TextField
+                      fullWidth
+                      label="Transaction Name Pattern"
+                      value={editingRule?.name_pattern || ''}
+                      onChange={(e) => editingRule && setEditingRule({ ...editingRule, name_pattern: e.target.value })}
                       disabled={isLoading}
-                      style={{
-                        backgroundColor: '#3b82f6',
-                        color: 'white'
-                      }}
-                    >
-                      {isLoading ? <CircularProgress size={20} color="inherit" /> : 'Update'}
-                    </Button>
-                  </Box>
-                </Card>
-              </Box>
-            )}
+                    />
+                  </Grid>
+                  <Grid item xs={12} sm={6}>
+                    <TextField
+                      fullWidth
+                      label="Target Category"
+                      value={editingRule?.target_category || ''}
+                      onChange={(e) => editingRule && setEditingRule({ ...editingRule, target_category: e.target.value })}
+                      disabled={isLoading}
+                    />
+                  </Grid>
+                </Grid>
+              </DialogContent>
+              <DialogActions sx={{ p: 2, pt: 0 }}>
+                <Button
+                  onClick={() => setEditingRule(null)}
+                  sx={{ color: 'text.secondary', textTransform: 'none' }}
+                  disabled={isLoading}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="contained"
+                  onClick={() => editingRule && handleUpdateRule(editingRule)}
+                  disabled={isLoading}
+                  sx={{
+                    bgcolor: '#3b82f6',
+                    '&:hover': { bgcolor: '#2563eb' },
+                    borderRadius: '8px',
+                    textTransform: 'none',
+                    fontWeight: 600,
+                    px: 3
+                  }}
+                >
+                  {isLoading ? <CircularProgress size={20} color="inherit" /> : 'Update'}
+                </Button>
+              </DialogActions>
+            </Dialog>
           </>
         )}
 
@@ -1751,158 +1766,142 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
             </Box>
           </>
         )}
-        {deletingCategory && (
-          <Box style={{
-            position: 'fixed',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            backgroundColor: 'rgba(0,0,0,0.5)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            zIndex: 9999
-          }}>
-            <Card style={{
-              padding: '24px',
-              maxWidth: '450px',
-              width: '100%',
-              margin: '16px',
+        <Dialog
+          open={Boolean(deletingCategory)}
+          onClose={() => {
+            setDeletingCategory(null);
+            setDeleteOptions({ deleteRules: true, deleteBudget: true });
+          }}
+          PaperProps={{
+            sx: {
               borderRadius: '16px',
-              backgroundColor: theme.palette.background.paper
-            }}>
-              <Typography variant="h6" style={{ marginBottom: '8px', fontWeight: 600, color: '#ef4444' }}>
-                Delete Category
-              </Typography>
-              <Typography variant="body2" color={theme.palette.text.secondary} style={{ marginBottom: '20px' }}>
-                Are you sure you want to delete "{deletingCategory}"? All transactions with this category will become uncategorized.
-              </Typography>
-
-              <Box style={{ marginBottom: '20px' }}>
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      checked={deleteOptions.deleteRules}
-                      onChange={(e) => setDeleteOptions({ ...deleteOptions, deleteRules: e.target.checked })}
-                      disabled={isLoading}
-                    />
-                  }
-                  label={<Typography variant="body2">Also delete categorization rules targeting this category</Typography>}
-                />
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      checked={deleteOptions.deleteBudget}
-                      onChange={(e) => setDeleteOptions({ ...deleteOptions, deleteBudget: e.target.checked })}
-                      disabled={isLoading}
-                    />
-                  }
-                  label={<Typography variant="body2">Also delete budget for this category</Typography>}
-                />
-              </Box>
-
-              <Box display="flex" gap="8px" justifyContent="flex-end">
-                <Button
-                  onClick={() => {
-                    setDeletingCategory(null);
-                    setDeleteOptions({ deleteRules: true, deleteBudget: true });
-                  }}
-                  style={{ color: theme.palette.text.secondary, textTransform: 'none' }}
-                  disabled={isLoading}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  variant="contained"
-                  onClick={handleDeleteCategory}
-                  disabled={isLoading}
-                  style={{
-                    backgroundColor: '#ef4444',
-                    color: 'white',
-                    borderRadius: '8px',
-                    textTransform: 'none',
-                    fontWeight: 600
-                  }}
-                >
-                  {isLoading ? <CircularProgress size={20} color="inherit" /> : 'Delete Category'}
-                </Button>
-              </Box>
-            </Card>
-          </Box>
-        )}
+              padding: '8px',
+              width: '100%',
+              maxWidth: '450px'
+            }
+          }}
+        >
+          <DialogTitle sx={{ fontWeight: 700, color: '#ef4444' }}>Delete Category</DialogTitle>
+          <DialogContent>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+              Are you sure you want to delete "{deletingCategory}"? All transactions with this category will become uncategorized.
+            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={deleteOptions.deleteRules}
+                    onChange={(e) => setDeleteOptions({ ...deleteOptions, deleteRules: e.target.checked })}
+                    disabled={isLoading}
+                  />
+                }
+                label={<Typography variant="body2">Also delete categorization rules targeting this category</Typography>}
+              />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={deleteOptions.deleteBudget}
+                    onChange={(e) => setDeleteOptions({ ...deleteOptions, deleteBudget: e.target.checked })}
+                    disabled={isLoading}
+                  />
+                }
+                label={<Typography variant="body2">Also delete budget for this category</Typography>}
+              />
+            </Box>
+          </DialogContent>
+          <DialogActions sx={{ p: 2, pt: 0 }}>
+            <Button
+              onClick={() => {
+                setDeletingCategory(null);
+                setDeleteOptions({ deleteRules: true, deleteBudget: true });
+              }}
+              sx={{ color: 'text.secondary', textTransform: 'none' }}
+              disabled={isLoading}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="contained"
+              onClick={handleDeleteCategory}
+              disabled={isLoading}
+              sx={{
+                bgcolor: '#ef4444',
+                '&:hover': { bgcolor: '#dc2626' },
+                borderRadius: '8px',
+                textTransform: 'none',
+                fontWeight: 600,
+                px: 3
+              }}
+            >
+              {isLoading ? <CircularProgress size={20} color="inherit" /> : 'Delete'}
+            </Button>
+          </DialogActions>
+        </Dialog>
 
         {/* Rename Category Dialog */}
-        {renamingCategory && (
-          <Box style={{
-            position: 'fixed',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            backgroundColor: 'rgba(0,0,0,0.5)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            zIndex: 9999
-          }}>
-            <Card style={{
-              padding: '24px',
-              maxWidth: '400px',
-              width: '100%',
-              margin: '16px',
+        <Dialog
+          open={Boolean(renamingCategory)}
+          onClose={() => {
+            setRenamingCategory(null);
+            setRenameNewName('');
+          }}
+          PaperProps={{
+            sx: {
               borderRadius: '16px',
-              backgroundColor: theme.palette.background.paper
-            }}>
-              <Typography variant="h6" style={{ marginBottom: '8px', fontWeight: 600 }}>
-                Rename Category
-              </Typography>
-              <Typography variant="body2" color={theme.palette.text.secondary} style={{ marginBottom: '20px' }}>
-                Rename "{renamingCategory}" to a new name. All transactions with this category will be updated.
-              </Typography>
-              <TextField
-                fullWidth
-                label="New Category Name"
-                value={renameNewName}
-                onChange={(e) => setRenameNewName(e.target.value)}
-                disabled={isLoading}
-                autoFocus
-                style={{ marginBottom: '20px' }}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' && renameNewName.trim() && renameNewName.trim() !== renamingCategory) {
-                    handleRenameCategory();
-                  }
-                }}
-              />
-              <Box display="flex" gap="8px" justifyContent="flex-end">
-                <Button
-                  onClick={() => {
-                    setRenamingCategory(null);
-                    setRenameNewName('');
-                  }}
-                  style={{ color: theme.palette.text.secondary, textTransform: 'none' }}
-                  disabled={isLoading}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  variant="contained"
-                  onClick={handleRenameCategory}
-                  disabled={isLoading || !renameNewName.trim() || renameNewName.trim() === renamingCategory}
-                  style={{
-                    backgroundColor: '#3b82f6',
-                    color: 'white',
-                    borderRadius: '8px',
-                    textTransform: 'none',
-                    fontWeight: 600
-                  }}
-                >
-                  {isLoading ? <CircularProgress size={20} color="inherit" /> : 'Rename'}
-                </Button>
-              </Box>
-            </Card>
-          </Box>
-        )}
+              padding: '8px',
+              width: '100%',
+              maxWidth: '400px'
+            }
+          }}
+        >
+          <DialogTitle sx={{ fontWeight: 700 }}>Rename Category</DialogTitle>
+          <DialogContent>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+              Rename "{renamingCategory}" to a new name. All transactions with this category will be updated.
+            </Typography>
+            <TextField
+              fullWidth
+              label="New Category Name"
+              value={renameNewName}
+              onChange={(e) => setRenameNewName(e.target.value)}
+              disabled={isLoading}
+              autoFocus
+              sx={{ mt: 1 }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && renameNewName.trim() && renameNewName.trim() !== renamingCategory) {
+                  handleRenameCategory();
+                }
+              }}
+            />
+          </DialogContent>
+          <DialogActions sx={{ p: 2, pt: 0 }}>
+            <Button
+              onClick={() => {
+                setRenamingCategory(null);
+                setRenameNewName('');
+              }}
+              sx={{ color: 'text.secondary', textTransform: 'none' }}
+              disabled={isLoading}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="contained"
+              onClick={handleRenameCategory}
+              disabled={isLoading || !renameNewName.trim() || renameNewName.trim() === renamingCategory}
+              sx={{
+                bgcolor: '#3b82f6',
+                '&:hover': { bgcolor: '#2563eb' },
+                borderRadius: '8px',
+                textTransform: 'none',
+                fontWeight: 600,
+                px: 3
+              }}
+            >
+              {isLoading ? <CircularProgress size={20} color="inherit" /> : 'Rename'}
+            </Button>
+          </DialogActions>
+        </Dialog>
       </DialogContent>
 
       <DialogActions style={{ padding: '16px 24px 24px 24px' }}>

--- a/app/components/CategoryDashboard/components/TransactionsTable.tsx
+++ b/app/components/CategoryDashboard/components/TransactionsTable.tsx
@@ -389,6 +389,16 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
                 getCardVendor={getCardVendor}
                 getCardNickname={getCardNickname}
                 showDate={!groupByDate}
+                isEditing={editingTransaction?.identifier === transaction.identifier}
+                editCategory={editCategory}
+                setEditCategory={setEditCategory}
+                availableCategories={availableCategories}
+                applyToAll={applyToAll}
+                setApplyToAll={setApplyToAll}
+                editPrice={editPrice}
+                setEditPrice={setEditPrice}
+                onSave={handleSaveClick}
+                onCancel={handleCancelClick}
               />
             )}
           />
@@ -420,6 +430,16 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
                         getCardVendor={getCardVendor}
                         getCardNickname={getCardNickname}
                         showDate={false}
+                        isEditing={editingTransaction?.identifier === transaction.identifier}
+                        editCategory={editCategory}
+                        setEditCategory={setEditCategory}
+                        availableCategories={availableCategories}
+                        applyToAll={applyToAll}
+                        setApplyToAll={setApplyToAll}
+                        editPrice={editPrice}
+                        setEditPrice={setEditPrice}
+                        onSave={handleSaveClick}
+                        onCancel={handleCancelClick}
                       />
                     ))}
                   </Box>
@@ -436,6 +456,16 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
                   getCardVendor={getCardVendor}
                   getCardNickname={getCardNickname}
                   showDate={true}
+                  isEditing={editingTransaction?.identifier === transaction.identifier}
+                  editCategory={editCategory}
+                  setEditCategory={setEditCategory}
+                  availableCategories={availableCategories}
+                  applyToAll={applyToAll}
+                  setApplyToAll={setApplyToAll}
+                  editPrice={editPrice}
+                  setEditPrice={setEditPrice}
+                  onSave={handleSaveClick}
+                  onCancel={handleCancelClick}
                 />
               ))
             )}
@@ -957,6 +987,16 @@ interface TransactionMobileCardProps {
   getCardVendor: (accountNumber: string | undefined | null) => string | null;
   getCardNickname: (accountNumber: string | undefined | null) => string | null | undefined;
   showDate?: boolean;
+  isEditing?: boolean;
+  editCategory?: string;
+  setEditCategory?: (val: string) => void;
+  availableCategories?: string[];
+  applyToAll?: boolean;
+  setApplyToAll?: (val: boolean) => void;
+  editPrice?: string;
+  setEditPrice?: (val: string) => void;
+  onSave?: () => void;
+  onCancel?: () => void;
 }
 
 // Card content component for MobileSortableTable (without Paper wrapper)
@@ -967,7 +1007,17 @@ const TransactionMobileCardContent = ({
   onDelete,
   getCardVendor,
   getCardNickname,
-  showDate
+  showDate,
+  isEditing,
+  editCategory,
+  setEditCategory,
+  availableCategories,
+  applyToAll,
+  setApplyToAll,
+  editPrice,
+  setEditPrice,
+  onSave,
+  onCancel
 }: TransactionMobileCardProps) => {
   const displayAmount = Math.abs(transaction.price);
 
@@ -991,45 +1041,76 @@ const TransactionMobileCardContent = ({
             </Typography>
           )}
         </Typography>
-        <Typography
-          variant="subtitle2"
-          sx={{
-            fontWeight: 800,
-            color: transaction.price < 0 ? '#ef4444' : '#10b981',
-            whiteSpace: 'nowrap'
-          }}
-        >
-          {transaction.price < 0 ? '-' : '+'}₪{formatNumber(displayAmount)}
-        </Typography>
+        {isEditing ? (
+          <TextField
+            value={editPrice}
+            onChange={(e) => setEditPrice?.(e.target.value)}
+            size="small"
+            type="number"
+            autoFocus
+            sx={{
+              width: '100px',
+              '& .MuiInputBase-input': {
+                fontWeight: 800,
+                fontSize: '14px',
+                color: transaction.price < 0 ? '#ef4444' : '#10b981',
+                textAlign: 'right',
+                py: 0.5
+              }
+            }}
+          />
+        ) : (
+          <Typography
+            variant="subtitle2"
+            sx={{
+              fontWeight: 800,
+              color: transaction.price < 0 ? '#ef4444' : '#10b981',
+              whiteSpace: 'nowrap'
+            }}
+          >
+            {transaction.price < 0 ? '-' : '+'}₪{formatNumber(displayAmount)}
+          </Typography>
+        )}
       </Box>
 
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1.5 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <span
-            style={{
-              padding: '2px 8px',
-              borderRadius: '6px',
-              backgroundColor: 'rgba(59, 130, 246, 0.1)',
-              color: '#3b82f6',
-              fontSize: '11px',
-              fontWeight: 600
-            }}
-          >
-            {transaction.category}
-          </span>
-          {transaction.installments_total && transaction.installments_total > 1 && (
-            <span style={{
-              color: '#6366f1',
-              fontSize: '10px',
-              fontWeight: '600',
-              backgroundColor: 'rgba(99, 102, 241, 0.1)',
-              padding: '2px 6px',
-              borderRadius: '4px'
-            }}>
-              {transaction.installments_number}/{transaction.installments_total}
+        <Box sx={{ flex: 1 }}>
+          {isEditing ? (
+            <CategoryAutocomplete
+              value={editCategory || ''}
+              onChange={setEditCategory || (() => { })}
+              options={availableCategories || []}
+              applyToAll={applyToAll || false}
+              onApplyToAllChange={setApplyToAll || (() => { })}
+              showApplyToAll={editCategory !== transaction.category}
+            />
+          ) : (
+            <span
+              style={{
+                padding: '2px 8px',
+                borderRadius: '6px',
+                backgroundColor: 'rgba(59, 130, 246, 0.1)',
+                color: '#3b82f6',
+                fontSize: '11px',
+                fontWeight: 600
+              }}
+            >
+              {transaction.category}
             </span>
           )}
         </Box>
+        {transaction.installments_total && transaction.installments_total > 1 && !isEditing && (
+          <span style={{
+            color: '#6366f1',
+            fontSize: '10px',
+            fontWeight: '600',
+            backgroundColor: 'rgba(99, 102, 241, 0.1)',
+            padding: '2px 6px',
+            borderRadius: '4px'
+          }}>
+            {transaction.installments_number}/{transaction.installments_total}
+          </span>
+        )}
         {transaction.original_currency && !['ILS', '₪', 'NIS'].includes(transaction.original_currency) && transaction.original_amount && (
           <Typography variant="caption" sx={{ color: theme.palette.text.secondary }}>
             {getCurrencySymbol(transaction.original_currency)}{formatNumber(Math.abs(transaction.original_amount))}
@@ -1045,12 +1126,25 @@ const TransactionMobileCardContent = ({
           </Typography>
         </Box>
         <Box sx={{ display: 'flex', gap: 0.5 }}>
-          <IconButton size="small" onClick={(e) => { e.stopPropagation(); onEdit(); }} sx={{ color: theme.palette.primary.main }}>
-            <EditIcon fontSize="small" />
-          </IconButton>
-          <IconButton size="small" onClick={(e) => { e.stopPropagation(); onDelete(); }} sx={{ color: theme.palette.error.main }}>
-            <DeleteIcon fontSize="small" />
-          </IconButton>
+          {isEditing ? (
+            <>
+              <IconButton size="small" onClick={(e) => { e.stopPropagation(); onSave?.(); }} sx={{ color: '#10b981' }}>
+                <CheckIcon fontSize="small" />
+              </IconButton>
+              <IconButton size="small" onClick={(e) => { e.stopPropagation(); onCancel?.(); }} sx={{ color: '#ef4444' }}>
+                <CloseIcon fontSize="small" />
+              </IconButton>
+            </>
+          ) : (
+            <>
+              <IconButton size="small" onClick={(e) => { e.stopPropagation(); onEdit(); }} sx={{ color: theme.palette.primary.main }}>
+                <EditIcon fontSize="small" />
+              </IconButton>
+              <IconButton size="small" onClick={(e) => { e.stopPropagation(); onDelete(); }} sx={{ color: theme.palette.error.main }}>
+                <DeleteIcon fontSize="small" />
+              </IconButton>
+            </>
+          )}
         </Box>
       </Box>
     </Box>
@@ -1064,7 +1158,17 @@ const TransactionMobileCard = ({
   onDelete,
   getCardVendor,
   getCardNickname,
-  showDate
+  showDate,
+  isEditing,
+  editCategory,
+  setEditCategory,
+  availableCategories,
+  applyToAll,
+  setApplyToAll,
+  editPrice,
+  setEditPrice,
+  onSave,
+  onCancel
 }: TransactionMobileCardProps) => {
   const displayAmount = Math.abs(transaction.price);
 
@@ -1083,82 +1187,33 @@ const TransactionMobileCard = ({
       sx={{
         p: 2,
         borderRadius: '16px',
-        border: `1px solid ${theme.palette.divider}`,
-        background: theme.palette.mode === 'dark' ? 'rgba(30, 41, 59, 0.4)' : 'rgba(255, 255, 255, 0.6)',
+        border: `1px solid ${isEditing ? theme.palette.primary.main : theme.palette.divider}`,
+        background: isEditing
+          ? (theme.palette.mode === 'dark' ? 'rgba(59, 130, 246, 0.1)' : 'rgba(59, 130, 246, 0.05)')
+          : (theme.palette.mode === 'dark' ? 'rgba(30, 41, 59, 0.4)' : 'rgba(255, 255, 255, 0.6)'),
         backdropFilter: 'blur(10px)',
+        transition: 'all 0.2s ease-in-out'
       }}
     >
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-        <Typography variant="subtitle2" sx={{ fontWeight: 700, flex: 1, mr: 1 }}>
-          {transaction.name}
-          {showDate && (
-            <Typography variant="caption" sx={{ display: 'block', color: 'text.secondary', fontWeight: 500, mt: 0.5 }}>
-              {dateUtils.formatDate(transaction.date)}
-            </Typography>
-          )}
-        </Typography>
-        <Typography
-          variant="subtitle2"
-          sx={{
-            fontWeight: 800,
-            color: transaction.price < 0 ? '#ef4444' : '#10b981',
-            whiteSpace: 'nowrap'
-          }}
-        >
-          {transaction.price < 0 ? '-' : '+'}₪{formatNumber(displayAmount)}
-        </Typography>
-      </Box>
-
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1.5 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <span
-            style={{
-              padding: '2px 8px',
-              borderRadius: '6px',
-              backgroundColor: 'rgba(59, 130, 246, 0.1)',
-              color: '#3b82f6',
-              fontSize: '11px',
-              fontWeight: 600
-            }}
-          >
-            {transaction.category}
-          </span>
-          {transaction.installments_total && transaction.installments_total > 1 && (
-            <span style={{
-              color: '#6366f1',
-              fontSize: '10px',
-              fontWeight: '600',
-              backgroundColor: 'rgba(99, 102, 241, 0.1)',
-              padding: '2px 6px',
-              borderRadius: '4px'
-            }}>
-              {transaction.installments_number}/{transaction.installments_total}
-            </span>
-          )}
-        </Box>
-        {transaction.original_currency && !['ILS', '₪', 'NIS'].includes(transaction.original_currency) && transaction.original_amount && (
-          <Typography variant="caption" sx={{ color: theme.palette.text.secondary }}>
-            {getCurrencySymbol(transaction.original_currency)}{formatNumber(Math.abs(transaction.original_amount))}
-          </Typography>
-        )}
-      </Box>
-
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <CardVendorIcon vendor={getCardVendor(transaction.account_number)} size={18} />
-          <Typography variant="caption" sx={{ color: theme.palette.text.secondary, fontWeight: 500 }}>
-            {getCardNickname(transaction.account_number) || (transaction.account_number ? `•••• ${transaction.account_number.slice(-4)}` : 'Card')}
-          </Typography>
-        </Box>
-        <Box sx={{ display: 'flex', gap: 0.5 }}>
-          <IconButton size="small" onClick={onEdit} sx={{ color: theme.palette.primary.main }}>
-            <EditIcon fontSize="small" />
-          </IconButton>
-          <IconButton size="small" onClick={onDelete} sx={{ color: theme.palette.error.main }}>
-            <DeleteIcon fontSize="small" />
-          </IconButton>
-        </Box>
-      </Box>
+      <TransactionMobileCardContent
+        transaction={transaction}
+        theme={theme}
+        onEdit={onEdit}
+        onDelete={onDelete}
+        getCardVendor={getCardVendor}
+        getCardNickname={getCardNickname}
+        showDate={showDate}
+        isEditing={isEditing}
+        editCategory={editCategory}
+        setEditCategory={setEditCategory}
+        availableCategories={availableCategories}
+        applyToAll={applyToAll}
+        setApplyToAll={setApplyToAll}
+        editPrice={editPrice}
+        setEditPrice={setEditPrice}
+        onSave={onSave}
+        onCancel={onCancel}
+      />
     </Paper>
   );
 };

--- a/app/components/RecurringPaymentsView.tsx
+++ b/app/components/RecurringPaymentsView.tsx
@@ -540,35 +540,66 @@ const RecurringPaymentsView: React.FC = () => {
                                             { id: 'next_payment_date', label: 'Next', align: 'center', sortable: true, format: (val) => val ? formatDate(val) : 'Completed' },
                                             { id: 'status', label: 'Status', align: 'center', sortable: true, format: (val) => <Chip label={val} size="small" color={val === 'completed' ? 'success' : 'primary'} sx={{ fontWeight: 600, borderRadius: '8px' }} /> }
                                         ]}
-                                        mobileCardRenderer={(row) => (
-                                            <Box>
-                                                <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-                                                    <Typography variant="subtitle2" fontWeight={700}>{row.name}</Typography>
-                                                    <Typography variant="subtitle2" sx={{ fontWeight: 800, color: theme.palette.primary.main }}>
-                                                        ₪{formatNumber(row.price)}
-                                                    </Typography>
-                                                </Box>
-                                                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                                                        {renderAccountInfo(row)}
-                                                        <Chip
-                                                            label={row.status}
-                                                            size="small"
-                                                            color={row.status === 'completed' ? 'success' : 'primary'}
-                                                            sx={{ height: 20, fontSize: '10px', borderRadius: '4px' }}
-                                                        />
-                                                    </Box>
-                                                    <Box sx={{ textAlign: 'right' }}>
-                                                        <Typography variant="caption" color="text.secondary" display="block">
-                                                            {row.current_installment}/{row.total_installments}
-                                                        </Typography>
-                                                        <Typography variant="caption" color="text.secondary">
-                                                            {row.next_payment_date ? formatDate(row.next_payment_date) : 'Completed'}
+                                        mobileCardRenderer={(row) => {
+                                            const index = installments.indexOf(row);
+                                            const isEditing = editingItem?.type === 'installment' && editingItem.index === index;
+                                            return (
+                                                <Box>
+                                                    <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                                                        <Typography variant="subtitle2" fontWeight={700}>{row.name}</Typography>
+                                                        <Typography variant="subtitle2" sx={{ fontWeight: 800, color: theme.palette.primary.main }}>
+                                                            ₪{formatNumber(row.price)}
                                                         </Typography>
                                                     </Box>
+                                                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+                                                        <Box sx={{ flex: 1 }}>
+                                                            {isEditing ? (
+                                                                <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px', mt: 1 }}>
+                                                                    <CategoryAutocomplete value={editCategory} onChange={setEditCategory} options={categories} autoFocus placeholder="Category" />
+                                                                    <CheckIcon fontSize="small" sx={{ cursor: 'pointer', color: 'success.main' }} onClick={(e) => { e.stopPropagation(); handleSaveCategory(); }} />
+                                                                    <CloseIcon fontSize="small" sx={{ cursor: 'pointer', color: 'error.main' }} onClick={(e) => { e.stopPropagation(); handleCancelCategory(); }} />
+                                                                </Box>
+                                                            ) : (
+                                                                <Box
+                                                                    onClick={(e) => handleCategoryClick(e, row, index, 'installment')}
+                                                                    sx={{ display: 'inline-flex', alignItems: 'center', gap: '4px', bgcolor: theme.palette.primary.main, color: 'white', px: 1, py: 0.5, borderRadius: 1.5, cursor: 'pointer', fontSize: '10px', fontWeight: 600 }}
+                                                                >
+                                                                    {row.category || 'Uncategorized'} <EditIcon sx={{ fontSize: '10px' }} />
+                                                                </Box>
+                                                            )}
+                                                        </Box>
+                                                        <Box sx={{ textAlign: 'right' }}>
+                                                            <Typography variant="caption" color="text.secondary" display="block">
+                                                                {row.current_installment}/{row.total_installments}
+                                                            </Typography>
+                                                            <Typography variant="caption" color="text.secondary">
+                                                                {row.next_payment_date ? formatDate(row.next_payment_date) : 'Completed'}
+                                                            </Typography>
+                                                        </Box>
+                                                    </Box>
+                                                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                                                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                                            {renderAccountInfo(row)}
+                                                            <Chip
+                                                                label={row.status}
+                                                                size="small"
+                                                                color={row.status === 'completed' ? 'success' : 'primary'}
+                                                                sx={{ height: 20, fontSize: '10px', borderRadius: '4px' }}
+                                                            />
+                                                        </Box>
+                                                        {!isEditing && (
+                                                            <IconButton
+                                                                size="small"
+                                                                onClick={(e) => handleCategoryClick(e, row, index, 'installment')}
+                                                                sx={{ color: 'primary.main', p: 0.5 }}
+                                                            >
+                                                                <EditIcon fontSize="small" />
+                                                            </IconButton>
+                                                        )}
+                                                    </Box>
                                                 </Box>
-                                            </Box>
-                                        )}
+                                            );
+                                        }}
                                     />
                                 ) : activeTab === 1 ? (
                                     <Table
@@ -625,34 +656,74 @@ const RecurringPaymentsView: React.FC = () => {
                                                 )
                                             }
                                         ]}
-                                        mobileCardRenderer={(row) => (
-                                            <Box>
-                                                <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-                                                    <Typography variant="subtitle2" fontWeight={700}>{row.name}</Typography>
-                                                    <Typography variant="subtitle2" sx={{ fontWeight: 800, color: theme.palette.primary.main }}>
-                                                        ₪{formatNumber(row.price)}
-                                                    </Typography>
-                                                </Box>
-                                                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                                                        {renderAccountInfo(row)}
-                                                        <Chip
-                                                            label={row.category || 'Uncategorized'}
-                                                            size="small"
-                                                            sx={{ height: 20, fontSize: '10px', borderRadius: '4px' }}
-                                                        />
-                                                    </Box>
-                                                    <Box sx={{ textAlign: 'right' }}>
-                                                        <Typography variant="caption" color="text.secondary" display="block">
-                                                            {row.month_count} months
-                                                        </Typography>
-                                                        <Typography variant="caption" color="text.secondary">
-                                                            Last: {formatDate(row.last_charge_date)}
+                                        mobileCardRenderer={(row) => {
+                                            const index = recurring.indexOf(row);
+                                            const isEditing = editingItem?.type === 'recurring' && editingItem.index === index;
+                                            return (
+                                                <Box>
+                                                    <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                                                        <Typography variant="subtitle2" fontWeight={700}>{row.name}</Typography>
+                                                        <Typography variant="subtitle2" sx={{ fontWeight: 800, color: theme.palette.primary.main }}>
+                                                            ₪{formatNumber(row.price)}
                                                         </Typography>
                                                     </Box>
+                                                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+                                                        <Box sx={{ flex: 1 }}>
+                                                            {isEditing ? (
+                                                                <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px', mt: 1 }}>
+                                                                    <CategoryAutocomplete value={editCategory} onChange={setEditCategory} options={categories} autoFocus placeholder="Category" />
+                                                                    <CheckIcon fontSize="small" sx={{ cursor: 'pointer', color: 'success.main' }} onClick={(e) => { e.stopPropagation(); handleSaveCategory(); }} />
+                                                                    <CloseIcon fontSize="small" sx={{ cursor: 'pointer', color: 'error.main' }} onClick={(e) => { e.stopPropagation(); handleCancelCategory(); }} />
+                                                                </Box>
+                                                            ) : (
+                                                                <Box
+                                                                    onClick={(e) => handleCategoryClick(e, row, index, 'recurring')}
+                                                                    sx={{ display: 'inline-flex', alignItems: 'center', gap: '4px', bgcolor: theme.palette.primary.main, color: 'white', px: 1, py: 0.5, borderRadius: 1.5, cursor: 'pointer', fontSize: '10px', fontWeight: 600 }}
+                                                                >
+                                                                    {row.category || 'Uncategorized'} <EditIcon sx={{ fontSize: '10px' }} />
+                                                                </Box>
+                                                            )}
+                                                        </Box>
+                                                        <Box sx={{ textAlign: 'right' }}>
+                                                            <Typography variant="caption" color="text.secondary" display="block">
+                                                                {row.month_count} months
+                                                            </Typography>
+                                                            <Typography variant="caption" color="text.secondary">
+                                                                Last: {formatDate(row.last_charge_date)}
+                                                            </Typography>
+                                                        </Box>
+                                                    </Box>
+                                                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                                                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                                            {renderAccountInfo(row)}
+                                                            {!isEditing && (
+                                                                <Chip
+                                                                    label={row.category || 'Uncategorized'}
+                                                                    size="small"
+                                                                    sx={{ height: 20, fontSize: '10px', borderRadius: '4px' }}
+                                                                />
+                                                            )}
+                                                        </Box>
+                                                        <Box sx={{ display: 'flex', gap: 0.5 }}>
+                                                            {!isEditing && (
+                                                                <IconButton
+                                                                    size="small"
+                                                                    onClick={(e) => handleCategoryClick(e, row, index, 'recurring')}
+                                                                    sx={{ color: 'primary.main', p: 0.5 }}
+                                                                >
+                                                                    <EditIcon fontSize="small" />
+                                                                </IconButton>
+                                                            )}
+                                                            <Tooltip title="Not a recurring payment">
+                                                                <IconButton size="small" onClick={(e) => { e.stopPropagation(); handleMarkNotRecurring(row); }} sx={{ p: 0.5 }}>
+                                                                    <BlockIcon fontSize="small" />
+                                                                </IconButton>
+                                                            </Tooltip>
+                                                        </Box>
+                                                    </Box>
                                                 </Box>
-                                            </Box>
-                                        )}
+                                            );
+                                        }}
                                     />
                                 ) : (
                                     <Table


### PR DESCRIPTION
## Motivation
Users were unable to edit categories on mobile devices. Clicking the edit (pencil) icon either did nothing visually or triggered inaccessible overlays. This PR restores full category editing capabilities to the mobile experience and improves overall touch accessibility.

## Description
- **Transactions Table**: Added inline editing for price and category within mobile transaction cards. Added dedicated Save/Cancel buttons for mobile edits.
- **Recurring Payments**: Enabled category editing for installments and recurring subscription cards on mobile.
- **Category Management**:
    - Increased `IconButton` sizes and padding for better touch targets.
    - Replaced custom `fixed` overlays with standard MUI `Dialog` components to fix z-index and scrolling issues on mobile browsers.
    - Improved grid responsiveness for name pattern and target category fields.

## Architecture
- **State Management**: Leveraged existing React state (`editingTransaction`, `editingItem`) and prop-drilled necessary handlers to mobile-specific presentation components.
- **Component Reusability**: Refactored `TransactionMobileCard` to accept editing props, allowing it to toggle between view and edit modes.
- **UI Consistency**: Migrated from ad-hoc absolute/fixed positioning to Material UI's `Dialog` system, ensuring consistent modal behavior and backdrop handling across all platforms.

## Efficiency
- Used `useMediaQuery` to switch renderers, ensuring the heavier desktop table isn't logic-active on mobile and vice-versa.
- Minimized layout shifts by using stable `Paper` containers for mobile cards.