### PR TITLE
chore: add SVG logo and favicon matching project theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="app/public/nudlers-logo.png" alt="Nudlers Logo" width="200"/>
+  <img src="docs/assets/logo-light.svg" alt="Nudlers Logo" width="320"/>
 </p>
 
 <h1 align="center">Nudlers</h1>

--- a/app/pages/_document.tsx
+++ b/app/pages/_document.tsx
@@ -7,7 +7,7 @@ export default function Document() {
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link href="https://fonts.googleapis.com/css2?family=Assistant:wght@400;500;600;700&family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
-        <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect x='10' y='10' width='80' height='80' rx='15' fill='black'/><text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='white' style='font-family: Roboto, sans-serif; font-weight: 700; font-size: 60px;'>C</text></svg>" />
+        <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0' y1='0' x2='1' y2='1'%3E%3Cstop offset='0%25' stop-color='%236366f1'/%3E%3Cstop offset='60%25' stop-color='%23a855f7'/%3E%3Cstop offset='100%25' stop-color='%23ec4899'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect width='32' height='32' rx='7' fill='%2316161f'/%3E%3Crect x='6' y='18' width='5' height='8' rx='1.5' fill='url(%23g)'/%3E%3Crect x='13.5' y='13' width='5' height='13' rx='1.5' fill='url(%23g)'/%3E%3Crect x='21' y='7' width='5' height='19' rx='1.5' fill='url(%23g)'/%3E%3C/svg%3E" />
         <meta name="description" content="Nudlers" />
       </Head>
       <body>

--- a/docs/assets/icon.svg
+++ b/docs/assets/icon.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#6366f1"/>
+      <stop offset="50%" stop-color="#a855f7"/>
+      <stop offset="100%" stop-color="#ec4899"/>
+    </linearGradient>
+    <linearGradient id="g2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#818cf8"/>
+      <stop offset="100%" stop-color="#6366f1"/>
+    </linearGradient>
+  </defs>
+  <!-- Card shape -->
+  <rect x="4" y="10" width="56" height="44" rx="10" fill="url(#g)" opacity="0.15" stroke="url(#g)" stroke-width="2"/>
+  <!-- Card stripe -->
+  <rect x="4" y="22" width="56" height="8" fill="url(#g)" opacity="0.3"/>
+  <!-- Chart bars -->
+  <rect x="14" y="36" width="8" height="14" rx="2" fill="url(#g2)"/>
+  <rect x="27" y="30" width="8" height="20" rx="2" fill="url(#g)"/>
+  <rect x="40" y="22" width="8" height="28" rx="2" fill="url(#g2)"/>
+  <!-- Shekel sign -->
+  <text x="50" y="18" font-family="Arial, sans-serif" font-weight="700" font-size="14" fill="url(#g)">&#8362;</text>
+</svg>

--- a/docs/assets/logo-light.svg
+++ b/docs/assets/logo-light.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 80" fill="none">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#6366f1"/>
+      <stop offset="50%" stop-color="#a855f7"/>
+      <stop offset="100%" stop-color="#ec4899"/>
+    </linearGradient>
+    <linearGradient id="g2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#818cf8"/>
+      <stop offset="100%" stop-color="#6366f1"/>
+    </linearGradient>
+  </defs>
+  <!-- Icon: stylized card with chart bars -->
+  <g transform="translate(4, 8)">
+    <rect x="0" y="12" width="52" height="40" rx="8" fill="url(#g)" opacity="0.12" stroke="url(#g)" stroke-width="1.5"/>
+    <rect x="0" y="22" width="52" height="8" fill="url(#g)" opacity="0.2"/>
+    <rect x="10" y="34" width="6" height="12" rx="1.5" fill="url(#g2)"/>
+    <rect x="20" y="28" width="6" height="18" rx="1.5" fill="url(#g)"/>
+    <rect x="30" y="22" width="6" height="24" rx="1.5" fill="url(#g2)"/>
+    <text x="42" y="18" font-family="Arial, sans-serif" font-weight="700" font-size="14" fill="url(#g)">&#8362;</text>
+  </g>
+  <!-- Wordmark (dark text for light backgrounds) -->
+  <text x="72" y="54" font-family="'Inter', -apple-system, BlinkMacSystemFont, sans-serif" font-weight="700" font-size="42" letter-spacing="-1.5" fill="#1a1a2e">Nudlers</text>
+</svg>

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 80" fill="none">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#6366f1"/>
+      <stop offset="50%" stop-color="#a855f7"/>
+      <stop offset="100%" stop-color="#ec4899"/>
+    </linearGradient>
+    <linearGradient id="g2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#818cf8"/>
+      <stop offset="100%" stop-color="#6366f1"/>
+    </linearGradient>
+  </defs>
+  <!-- Icon: stylized wallet/card with chart bars -->
+  <g transform="translate(4, 8)">
+    <!-- Card shape -->
+    <rect x="0" y="12" width="52" height="40" rx="8" fill="url(#g)" opacity="0.15" stroke="url(#g)" stroke-width="1.5"/>
+    <!-- Card stripe -->
+    <rect x="0" y="22" width="52" height="8" fill="url(#g)" opacity="0.25"/>
+    <!-- Chart bars inside card -->
+    <rect x="10" y="34" width="6" height="12" rx="1.5" fill="url(#g2)"/>
+    <rect x="20" y="28" width="6" height="18" rx="1.5" fill="url(#g)"/>
+    <rect x="30" y="22" width="6" height="24" rx="1.5" fill="url(#g2)"/>
+    <!-- Shekel sign top-right -->
+    <text x="42" y="18" font-family="Arial, sans-serif" font-weight="700" font-size="14" fill="url(#g)">&#8362;</text>
+  </g>
+  <!-- Wordmark -->
+  <text x="72" y="54" font-family="'Inter', -apple-system, BlinkMacSystemFont, sans-serif" font-weight="700" font-size="42" letter-spacing="-1.5" fill="#e4e4ec">Nudlers</text>
+</svg>

--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#6366f1"/>
+      <stop offset="60%" stop-color="#a855f7"/>
+      <stop offset="100%" stop-color="#ec4899"/>
+    </linearGradient>
+  </defs>
+  <!-- Background -->
+  <rect width="32" height="32" rx="7" fill="#16161f"/>
+  <!-- Chart bars -->
+  <rect x="6" y="18" width="5" height="8" rx="1.5" fill="url(#g)"/>
+  <rect x="13.5" y="13" width="5" height="13" rx="1.5" fill="url(#g)"/>
+  <rect x="21" y="7" width="5" height="19" rx="1.5" fill="url(#g)"/>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Nudlers - Personal Finance for Israeli Banks</title>
     <meta name="description" content="Self-hosted personal finance app that aggregates transactions from Israeli banks and credit cards. Track expenses, set budgets, and get AI-powered insights.">
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
+    <link rel="apple-touch-icon" href="apple-touch-icon.png">
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -14,7 +16,7 @@
 
 <nav class="nav">
     <div class="nav-inner">
-        <a href="#" class="nav-logo">Nudlers</a>
+        <a href="#" class="nav-logo"><img src="assets/icon.svg" alt="" class="nav-logo-img">Nudlers</a>
         <div class="nav-links">
             <a href="#preview">Preview</a>
             <a href="#features">Features</a>
@@ -30,6 +32,7 @@
 
 <header class="hero">
     <div class="container">
+        <img src="assets/logo.svg" alt="Nudlers" class="hero-logo">
         <div class="hero-badge">Self-hosted &middot; Open Source &middot; Privacy First</div>
         <h1>Take control of your<br><span class="gradient-text">Israeli finances</span></h1>
         <p class="hero-sub">
@@ -353,7 +356,7 @@ npm run dev</code></pre>
     <div class="container">
         <div class="footer-inner">
             <div class="footer-brand">
-                <span class="footer-logo">Nudlers</span>
+                <div class="footer-logo"><img src="assets/icon.svg" alt="" class="footer-logo-img">Nudlers</div>
                 <p>Self-hosted personal finance for Israeli banks.</p>
             </div>
             <div class="footer-links">

--- a/docs/style.css
+++ b/docs/style.css
@@ -109,6 +109,9 @@ ul li::before {
 }
 
 .nav-logo {
+    display: flex;
+    align-items: center;
+    gap: 8px;
     font-size: 1.25rem;
     font-weight: 700;
     color: var(--text);
@@ -117,6 +120,11 @@ ul li::before {
 
 .nav-logo:hover {
     color: var(--text);
+}
+
+.nav-logo-img {
+    height: 28px;
+    width: auto;
 }
 
 .nav-links {
@@ -185,6 +193,14 @@ ul li::before {
 .hero {
     padding: calc(var(--nav-height) + 80px) 0 100px;
     text-align: center;
+}
+
+.hero-logo {
+    display: block;
+    width: 280px;
+    height: auto;
+    margin: 0 auto 24px;
+    filter: drop-shadow(0 4px 24px rgba(99, 102, 241, 0.25));
 }
 
 .hero-badge {
@@ -788,9 +804,17 @@ ul li::before {
 }
 
 .footer-logo {
+    display: flex;
+    align-items: center;
+    gap: 8px;
     font-size: 1.1rem;
     font-weight: 700;
     margin-bottom: 6px;
+}
+
+.footer-logo-img {
+    height: 24px;
+    width: auto;
 }
 
 .footer-brand p {


### PR DESCRIPTION
Design a clean SVG logo with credit card + chart bars icon, shekel symbol, and "Nudlers" wordmark using the site's indigo→purple→pink gradient. Includes:

- logo.svg: full logo for dark backgrounds (hero)
- logo-light.svg: full logo for light backgrounds (README)
- icon.svg: icon-only for nav and footer
- favicon.svg: bold 3-bar chart icon at 32x32 with dark bg

Update index.html (nav logo, hero logo, footer logo, favicon), style.css (logo layout styles), _document.tsx (inline SVG favicon), and README.md (SVG logo).