### PR TITLE
feature: multi arch arm64 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,24 +197,19 @@ jobs:
       - name: Wait for server to respond
         run: |
           echo "Waiting for server to start..."
-          for i in $(seq 1 90); do
-            # Check container hasn't crashed
+          for i in $(seq 1 120); do
             if ! docker ps -q -f name=smoke-test | grep -q .; then
               echo "::error::Container exited prematurely"
               docker logs smoke-test
               exit 1
             fi
-
-            # Check if server responds (any HTTP status is fine - DB isn't available)
-            if curl -so /dev/null http://localhost:3000 2>/dev/null; then
+            if curl -so /dev/null --max-time 2 http://localhost:3000 2>/dev/null; then
               echo "Server responded on port 3000 after ${i}s"
               exit 0
             fi
-
             sleep 1
           done
-
-          echo "::error::Server did not respond within 90 seconds"
+          echo "::error::Server did not respond within 120 seconds"
           docker logs smoke-test
           exit 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
           context: ./app
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          provenance: false
           cache-from: type=gha,scope=build-${{ steps.prep.outputs.pair }}
           cache-to: type=gha,scope=build-${{ steps.prep.outputs.pair }},mode=max
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,3 +148,76 @@ jobs:
           docker buildx imagetools create \
             -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.branch_name.outputs.branch }} \
             $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+  smoke-test:
+    if: github.event_name == 'push'
+    needs: [push-manifest]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [linux/amd64, linux/arm64]
+    steps:
+      - name: Set up QEMU
+        if: matrix.platform == 'linux/arm64'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Extract branch name
+        id: branch_name
+        run: echo "branch=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull image
+        run: |
+          docker pull --platform ${{ matrix.platform }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.branch_name.outputs.branch }}
+
+      - name: Verify architecture
+        run: |
+          EXPECTED_ARCH="${{ matrix.platform == 'linux/arm64' && 'arm64' || 'amd64' }}"
+          ACTUAL_ARCH=$(docker inspect \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.branch_name.outputs.branch }} \
+            --format '{{.Architecture}}')
+          echo "Expected: $EXPECTED_ARCH, Actual: $ACTUAL_ARCH"
+          [ "$ACTUAL_ARCH" = "$EXPECTED_ARCH" ] || { echo "Architecture mismatch!"; exit 1; }
+
+      - name: Start container
+        run: |
+          docker run -d --name smoke-test \
+            --platform ${{ matrix.platform }} \
+            -p 3000:3000 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.branch_name.outputs.branch }}
+
+      - name: Wait for server to respond
+        run: |
+          echo "Waiting for server to start..."
+          for i in $(seq 1 90); do
+            # Check container hasn't crashed
+            if ! docker ps -q -f name=smoke-test | grep -q .; then
+              echo "::error::Container exited prematurely"
+              docker logs smoke-test
+              exit 1
+            fi
+
+            # Check if server responds (any HTTP status is fine - DB isn't available)
+            if curl -so /dev/null http://localhost:3000 2>/dev/null; then
+              echo "Server responded on port 3000 after ${i}s"
+              exit 0
+            fi
+
+            sleep 1
+          done
+
+          echo "::error::Server did not respond within 90 seconds"
+          docker logs smoke-test
+          exit 1
+
+      - name: Show container logs
+        if: always()
+        run: docker logs smoke-test 2>&1 || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,17 +55,25 @@ jobs:
           NUDLERS_ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
         run: cd app && npm test
 
-  build-branch-image:
+  build:
     if: github.event_name == 'push'
-    needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [linux/amd64, linux/arm64]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Prepare platform pair
+        id: prep
+        run: echo "pair=${platform//\//-}" >> $GITHUB_OUTPUT
+        env:
+          platform: ${{ matrix.platform }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -80,18 +88,62 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: ./app
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=build-${{ steps.prep.outputs.pair }}
+          cache-to: type=gha,scope=build-${{ steps.prep.outputs.pair }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ steps.prep.outputs.pair }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  push-manifest:
+    if: github.event_name == 'push'
+    needs: [test, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
       - name: Extract branch name
         id: branch_name
         run: echo "branch=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+      - name: Download digests
+        uses: actions/download-artifact@v4
         with:
-          context: ./app
-          platforms: linux/amd64
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.branch_name.outputs.branch }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            BUILDKIT_INLINE_CACHE=1
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.branch_name.outputs.branch }} \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,7 @@ jobs:
           context: ./app
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          provenance: false
           cache-from: type=gha,scope=build-${{ steps.prep.outputs.pair }}
           cache-to: type=gha,scope=build-${{ steps.prep.outputs.pair }},mode=max
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,16 +29,24 @@ jobs:
       - name: Run unit tests
         run: cd app && npm test
 
-  build-latest-image:
-    needs: test
+  build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [linux/amd64, linux/arm64]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Prepare platform pair
+        id: prep
+        run: echo "pair=${platform//\//-}" >> $GITHUB_OUTPUT
+        env:
+          platform: ${{ matrix.platform }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -53,14 +61,57 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: ./app
-          platforms: linux/amd64
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            BUILDKIT_INLINE_CACHE=1
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=build-${{ steps.prep.outputs.pair }}
+          cache-to: type=gha,scope=build-${{ steps.prep.outputs.pair }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ steps.prep.outputs.pair }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  push-manifest:
+    needs: [test, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,7 @@ jobs:
             org.opencontainers.image.version=${{ needs.release.outputs.version_number }}
             org.opencontainers.image.revision=${{ github.sha }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          provenance: false
           cache-from: type=gha,scope=build-${{ steps.prep.outputs.pair }}
           cache-to: type=gha,scope=build-${{ steps.prep.outputs.pair }},mode=max
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: write
-
+    outputs:
+      version_number: ${{ steps.next_version.outputs.version_number }}
+      major_version: ${{ steps.next_version.outputs.major_version }}
+      new_version: ${{ steps.next_version.outputs.new_version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -47,16 +49,16 @@ jobs:
         run: |
           LATEST_TAG="${{ steps.get_latest_tag.outputs.latest_tag }}"
           VERSION_TYPE="${{ github.event.inputs.version_type }}"
-          
+
           # Remove 'v' prefix and split into parts
           VERSION=${LATEST_TAG#v}
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
-          
+
           # Default to 0 if empty
           MAJOR=${MAJOR:-0}
           MINOR=${MINOR:-0}
           PATCH=${PATCH:-0}
-          
+
           # Bump version based on type
           case $VERSION_TYPE in
             major)
@@ -72,7 +74,7 @@ jobs:
               PATCH=$((PATCH + 1))
               ;;
           esac
-          
+
           NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
           echo "New version: $NEW_VERSION"
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
@@ -107,7 +109,7 @@ jobs:
         run: |
           LATEST_TAG="${{ steps.get_latest_tag.outputs.latest_tag }}"
           NEW_VERSION="${{ steps.next_version.outputs.new_version }}"
-          
+
           # Generate changelog from commits since last tag
           if [ "$LATEST_TAG" = "v0.0.0" ]; then
             # First release - get all commits
@@ -116,12 +118,12 @@ jobs:
             # Get commits since last tag
             CHANGELOG=$(git log --pretty=format:"- %s (%h)" --no-merges ${LATEST_TAG}..HEAD | head -50)
           fi
-          
+
           # Handle empty changelog
           if [ -z "$CHANGELOG" ]; then
             CHANGELOG="- No changes since last release"
           fi
-          
+
           # Save to file to preserve newlines
           echo "$CHANGELOG" > changelog.txt
 
@@ -137,9 +139,26 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  build:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [linux/amd64, linux/arm64]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
+      - name: Prepare platform pair
+        id: prep
+        run: echo "pair=${platform//\//-}" >> $GITHUB_OUTPUT
+        env:
+          platform: ${{ matrix.platform }}
 
-      # Docker build steps
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -153,35 +172,77 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: ./app
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.next_version.outputs.version_number }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.next_version.outputs.major_version }}-latest
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          platforms: ${{ matrix.platform }}
           labels: |
             org.opencontainers.image.title=${{ github.repository }}
-            org.opencontainers.image.version=${{ steps.next_version.outputs.version_number }}
+            org.opencontainers.image.version=${{ needs.release.outputs.version_number }}
             org.opencontainers.image.revision=${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            BUILDKIT_INLINE_CACHE=1
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=build-${{ steps.prep.outputs.pair }}
+          cache-to: type=gha,scope=build-${{ steps.prep.outputs.pair }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ steps.prep.outputs.pair }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  push-manifest:
+    needs: [release, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.release.outputs.version_number }} \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.release.outputs.major_version }}-latest \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
 
       - name: Summary
         run: |
-          echo "## 🚀 Release Created!" >> $GITHUB_STEP_SUMMARY
+          echo "## Release Created!" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** ${{ steps.next_version.outputs.new_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** ${{ needs.release.outputs.new_version }}" >> $GITHUB_STEP_SUMMARY
           echo "**Type:** ${{ github.event.inputs.version_type }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 🐳 Docker Image Published" >> $GITHUB_STEP_SUMMARY
+          echo "### Docker Image Published (linux/amd64 + linux/arm64)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Docker image tags:" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.next_version.outputs.version_number }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.next_version.outputs.major_version }}-latest\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.release.outputs.version_number }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.release.outputs.major_version }}-latest\`" >> $GITHUB_STEP_SUMMARY
           echo "- \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest\`" >> $GITHUB_STEP_SUMMARY

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,7 +1,7 @@
 # =============================================================================
 # Stage 1: Dependencies
 # =============================================================================
-FROM --platform=linux/amd64 node:22-bookworm-slim AS deps
+FROM node:22-bookworm-slim AS deps
 
 WORKDIR /app
 
@@ -18,7 +18,7 @@ RUN npm ci
 # =============================================================================
 # Stage 2: Builder
 # =============================================================================
-FROM --platform=linux/amd64 node:22-bookworm-slim AS builder
+FROM node:22-bookworm-slim AS builder
 
 WORKDIR /app
 
@@ -35,7 +35,7 @@ RUN npm run build
 # Stage 3: Runner
 # =============================================================================
 # Use a slim Node image and install ONLY the required system dependencies for Chromium
-FROM --platform=linux/amd64 node:22-bookworm-slim AS runner
+FROM node:22-bookworm-slim AS runner
 
 WORKDIR /app
 


### PR DESCRIPTION
- Add ARM64 (linux/arm64) builds alongside existing amd64 across all CI workflows
- Build platforms in parallel using a matrix strategy with per-platform digest push and merged manifest
- Add a smoke-test job that pulls the built image for each platform, verifies the architecture, starts the container, and confirms the Next.js server responds on port 3000
- Disable provenance attestations to prevent the unknown/unknown platform entry in multi-arch manifests

## Test plan
- [ ] Verify `build` matrix runs both linux/amd64 and linux/arm64
- [ ] Verify `push-manifest` creates a multi-arch manifest with both platforms
- [ ] Verify `smoke-test` passes for both amd64 and arm64
- [ ] Verify no unknown/unknown entry in GHCR package manifest'
