### PR TITLE
fix(ui): prevent scroll jump and UI collapse on transaction category edit

### DIFF
--- a/app/components/CategoryDashboard/components/TransactionsTable.tsx
+++ b/app/components/CategoryDashboard/components/TransactionsTable.tsx
@@ -161,34 +161,15 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
                 });
               }
             } else {
-              // Apply to THIS transaction only - no rule created
-              const response = await fetch(`/api/transactions/${editingTransaction.identifier}|${editingTransaction.vendor}`, {
-                method: 'PUT',
-                headers: {
-                  'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                  category: editCategory,
-                  ...(priceChanged && { price: priceWithSign })
-                }),
+              // Apply to THIS transaction only - use the onUpdate callback 
+              // which handles both the API call and the optimistic local state update
+              onUpdate?.(editingTransaction, priceWithSign, editCategory);
+
+              setSnackbar({
+                open: true,
+                message: `Category updated to "${editCategory}" for this transaction only.`,
+                severity: 'success'
               });
-
-              if (response.ok) {
-                setSnackbar({
-                  open: true,
-                  message: `Category updated to "${editCategory}" for this transaction only.`,
-                  severity: 'success'
-                });
-
-                // Trigger a refresh of the dashboard data
-                window.dispatchEvent(new CustomEvent('dataRefresh'));
-              } else {
-                setSnackbar({
-                  open: true,
-                  message: 'Failed to update transaction',
-                  severity: 'error'
-                });
-              }
             }
           } else if (priceChanged) {
             // Only price changed, use the regular update callback

--- a/app/components/CategoryDashboard/useTransactions.ts
+++ b/app/components/CategoryDashboard/useTransactions.ts
@@ -31,9 +31,13 @@ export function useTransactions() {
     sd: string, ed: string, bc?: string, isLoadMore: boolean = false
   ) => {
     if (!isLoadMore) {
-      setLoadingTransactions(true);
+      // If we already have transactions, don't show the main loading spinner 
+      // to prevent the UI from "jumping" during a refresh
+      if (transactions.length === 0) {
+        setLoadingTransactions(true);
+      }
       pageRef.current = 0;
-      setTransactions([]);
+      // Don't clear transactions immediately to keep the UI stable
     } else {
       setLoadingMore(true);
     }
@@ -96,9 +100,12 @@ export function useTransactions() {
     }
 
     if (!isLoadMore) {
-      setLoadingTransactions(true);
+      // If we already have transactions, don't show the main loading spinner
+      if (transactions.length === 0) {
+        setLoadingTransactions(true);
+      }
       pageRef.current = 0;
-      setTransactions([]);
+      // Don't clear transactions immediately to keep the UI stable
     } else {
       setLoadingMore(true);
     }
@@ -174,7 +181,7 @@ export function useTransactions() {
   };
 
   // Keep a stable ref for the refresh handler to avoid re-attaching event listeners
-  const refreshRef = React.useRef(() => {});
+  const refreshRef = React.useRef(() => { });
   React.useEffect(() => {
     refreshRef.current = () => {
       if (startDate && endDate) {


### PR DESCRIPTION
# Motivation
Users experienced a disruptive UI experience where editing a transaction category caused the screen to jump to the top, losing their scroll position. This made managing large sets of transactions tedious.

# Description
This PR introduces two main changes to stabilize the UI:
1. **Optimistic UI Updates**: Single transaction category edits now update the local state immediately using the `onUpdate` callback, avoiding a full table refresh.
2. **Stable Refresh Logic**: The `useTransactions` hook was updated to maintain the current transaction list during background refreshes instead of clearing it. This prevents the "Loading" state from collapsing the table and resetting the scroll.

# Architecture
- The `TransactionsTable` now delegates single-update API calls to `useTransactions` via the existing `onUpdate` prop.
- `useTransactions` leverages React `setTransactions` with optimistic data while the background fetch (via `fetchTransactionsWithRange`) is in progress.
- Enhanced `isLoading` check in `useTransactions` to only show the main spinner if the transaction list is truly empty.