### PR TITLE
fix(vault): JSON-encode vault_salt before inserting into app_settings

### DIFF
--- a/app/pages/api/vault/change-passphrase.js
+++ b/app/pages/api/vault/change-passphrase.js
@@ -122,7 +122,7 @@ export default async function handler(req, res) {
             `INSERT INTO app_settings (key, value, description)
              VALUES ('vault_salt', $1, 'Random salt for vault key derivation (scrypt)')
              ON CONFLICT (key) DO UPDATE SET value = $1`,
-            [newSaltHex]
+            [JSON.stringify(newSaltHex)]
         );
         await client.query(
             "UPDATE app_settings SET value = $1 WHERE key = 'wrapped_master_key'",

--- a/app/pages/api/vault/initialize.js
+++ b/app/pages/api/vault/initialize.js
@@ -45,7 +45,7 @@ export default async function handler(req, res) {
             `INSERT INTO app_settings (key, value, description)
              VALUES ('vault_salt', $1, 'Random salt for vault key derivation (scrypt)')
              ON CONFLICT (key) DO UPDATE SET value = $1`,
-            [salt.toString('hex')]
+            [JSON.stringify(salt.toString('hex'))]
         );
         await client.query(
             `INSERT INTO app_settings (key, value, description)

--- a/app/utils/vault-utils.js
+++ b/app/utils/vault-utils.js
@@ -106,7 +106,7 @@ async function migrateLegacyVault(passphrase, masterKey) {
             `INSERT INTO app_settings (key, value, description)
              VALUES ('vault_salt', $1, 'Random salt for vault key derivation (scrypt)')
              ON CONFLICT (key) DO UPDATE SET value = $1`,
-            [newSalt.toString('hex')]
+            [JSON.stringify(newSalt.toString('hex'))]
         );
         await client.query(
             "UPDATE app_settings SET value = $1 WHERE key = 'wrapped_master_key'",


### PR DESCRIPTION
app_settings.value is a JSON column — every insert must be valid JSON. vault_salt was being inserted as a raw hex string (invalid JSON), causing "invalid input syntax for type json" errors during migration and init. Wrap all three insert sites with JSON.stringify() to match how wrapped_master_key is already stored.

https://claude.ai/code/session_01K1gQ9caju2kobvZJPGvc2k