### PR TITLE
fix: make migrations idempotent for fresh DB + Docker init

### DIFF
--- a/app/migrations/005_add_is_hidden_to_accounts.sql
+++ b/app/migrations/005_add_is_hidden_to_accounts.sql
@@ -1,2 +1,7 @@
 -- Add is_hidden flag to card_ownership to allow users to hide duplicate or junk accounts
-ALTER TABLE card_ownership ADD COLUMN is_hidden BOOLEAN DEFAULT false;
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'card_ownership' AND column_name = 'is_hidden') THEN
+    ALTER TABLE card_ownership ADD COLUMN is_hidden BOOLEAN DEFAULT false;
+  END IF;
+END $$;

--- a/app/migrations/007_add_vault_setting.sql
+++ b/app/migrations/007_add_vault_setting.sql
@@ -1,6 +1,6 @@
 -- Migration to add support for database-backed vault
--- NOTE: value is intentionally an empty string (not '""') so that
--- initialize.js can detect an uninitialized vault with a simple length > 0 check.
+-- NOTE: value is '""' (JSON empty string) so initialize.js can detect uninitialized vault with length > 0 check.
+-- JSONB requires valid JSON; '' is invalid; '""' parses to empty string.
 INSERT INTO app_settings (key, value, description) VALUES
-  ('wrapped_master_key', '', 'The master key wrapped with a passphrase for memory-locked credentials')
+  ('wrapped_master_key', '""', 'The master key wrapped with a passphrase for memory-locked credentials')
 ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
- 005: wrap ADD COLUMN is_hidden in DO block with IF NOT EXISTS check (fixes conflict when Docker init runs migrations before app)
- 007: use valid JSON '' instead of '' for wrapped_master_key value (JSONB rejects empty string; '' parses to empty string for vault check)