### PR TITLE
docs(ui): explain passphrase-wraps-key encryption model in vault screen

### DIFF
--- a/app/components/VaultLockScreen.tsx
+++ b/app/components/VaultLockScreen.tsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { Box, Typography, TextField, Button, Dialog, DialogContent, InputAdornment, IconButton, CircularProgress, Alert } from '@mui/material';
+import { Box, Typography, TextField, Button, Dialog, DialogContent, InputAdornment, IconButton, CircularProgress, Alert, Collapse } from '@mui/material';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import FingerprintIcon from '@mui/icons-material/Fingerprint';
 import KeyIcon from '@mui/icons-material/Key';
 import CloseIcon from '@mui/icons-material/Close';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import { styled } from '@mui/material/styles';
 import { useStatus } from '../context/StatusContext';
 
@@ -49,6 +51,7 @@ const VaultLockScreen: React.FC = () => {
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [showPasskeySetup, setShowPasskeySetup] = useState(false);
+    const [showSecurityDetails, setShowSecurityDetails] = useState(false);
 
     // Determine mode: migrate > init > unlock
     const isMigrate = needsMigration;
@@ -357,10 +360,10 @@ const VaultLockScreen: React.FC = () => {
 
                             <Typography variant="body1" sx={{ color: 'var(--n-text-secondary)', mb: 4, textAlign: 'center' }}>
                                 {isMigrate
-                                    ? 'Your credentials are currently using a legacy encryption key. Create a vault passphrase to upgrade to the secure Memory-Locked Vault.'
+                                    ? 'Create a passphrase to encrypt a new master key that will re-encrypt your credentials. The passphrase is never stored — losing it makes the vault unrecoverable.'
                                     : isInit
-                                        ? 'Create a passphrase to secure your bank and credit card credentials in memory.'
-                                        : 'Credentials are encrypted and locked in memory. Enter your passphrase to continue.'}
+                                        ? 'Your passphrase encrypts a master key, which in turn encrypts your credentials. The passphrase is never stored — losing it makes the vault unrecoverable.'
+                                        : 'Your passphrase decrypts the master key into memory, which unlocks your credentials. The key is cleared on server restart.'}
                             </Typography>
 
                             {error && (
@@ -486,7 +489,44 @@ const VaultLockScreen: React.FC = () => {
                                 )}
                             </form>
 
-                            <Typography variant="body2" sx={{ color: 'var(--n-text-muted)', mt: 3, textAlign: 'center', fontSize: '0.75rem' }}>
+                            <Button
+                                variant="text"
+                                size="small"
+                                onClick={() => setShowSecurityDetails(v => !v)}
+                                endIcon={showSecurityDetails ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                                sx={{
+                                    mt: 2,
+                                    color: 'var(--n-text-muted)',
+                                    textTransform: 'none',
+                                    fontSize: '0.75rem',
+                                    '&:hover': { color: 'var(--n-text-secondary)', backgroundColor: 'transparent' }
+                                }}
+                            >
+                                How encryption works
+                            </Button>
+
+                            <Collapse in={showSecurityDetails} sx={{ width: '100%' }}>
+                                <Box sx={{
+                                    mt: 1,
+                                    p: 2,
+                                    borderRadius: 'var(--n-radius-lg)',
+                                    backgroundColor: 'var(--n-bg-surface-alt)',
+                                    border: '1px solid var(--n-border)',
+                                }}>
+                                    <Typography variant="caption" sx={{ color: 'var(--n-text-muted)', display: 'block', fontFamily: 'monospace', lineHeight: 2, whiteSpace: 'pre' }}>
+                                        {
+`Passphrase ──scrypt──▶ Wrapping Key
+Wrapping Key ─AES-256-GCM─▶ Master Key (DB)
+Master Key ─AES-256-GCM─▶ Credentials (DB)`
+                                        }
+                                    </Typography>
+                                    <Typography variant="caption" sx={{ color: 'var(--n-text-muted)', display: 'block', mt: 1, lineHeight: 1.6 }}>
+                                        On unlock, the master key is decrypted into memory only — never written to disk. It is cleared when the server restarts.
+                                    </Typography>
+                                </Box>
+                            </Collapse>
+
+                            <Typography variant="body2" sx={{ color: 'var(--n-text-muted)', mt: 2, textAlign: 'center', fontSize: '0.75rem' }}>
                                 Unlocking is only required for syncing and credential management.
                                 Data viewing and navigation are fully available.
                             </Typography>

--- a/docs/index.html
+++ b/docs/index.html
@@ -467,10 +467,31 @@ npm run dev</code></pre>
                     <summary class="faq-question">How are my bank credentials stored?</summary>
                     <div class="faq-answer">
                         <p>
-                            Your credentials are stored encrypted in the database using AES-256 encryption.
-                            Nudlers uses a Memory-Locked Vault where your master key exists only in RAM
-                            while the vault is unlocked. Even if your database is compromised,
-                            your credentials remain secure.
+                            Your credentials are stored encrypted in the database using AES-256-GCM encryption.
+                            Nudlers uses a two-layer encryption model: a random master key encrypts your
+                            credentials, and that master key is itself encrypted by a key derived from your
+                            vault passphrase. Even if your database is compromised, credentials remain secure
+                            because the master key is never stored in plain form — only its encrypted version is.
+                        </p>
+                    </div>
+                </details>
+
+                <details class="faq-item">
+                    <summary class="faq-question">What does the vault passphrase protect, and is it stored anywhere?</summary>
+                    <div class="faq-answer">
+                        <p>
+                            The passphrase is <strong>never stored</strong>. Instead, it is used to derive a
+                            wrapping key (via scrypt, a memory-hard key derivation function) that encrypts the
+                            master key. The full chain looks like this:
+                        </p>
+                        <pre style="background:var(--bg-surface,#1e1e2e);border-radius:8px;padding:1rem;font-size:0.82rem;overflow-x:auto;margin:0.75rem 0;">Passphrase ──scrypt──▶ Wrapping Key
+Wrapping Key ─AES-256-GCM─▶ Master Key (stored encrypted in DB)
+Master Key ─AES-256-GCM─▶ Your credentials (stored encrypted in DB)</pre>
+                        <p>
+                            Once you unlock the vault, the master key is decrypted into server memory only —
+                            it is never written to disk. It is cleared automatically when the server restarts,
+                            requiring you to unlock again. If you forget your passphrase, the master key (and
+                            everything it protects) becomes permanently inaccessible.
                         </p>
                     </div>
                 </details>


### PR DESCRIPTION
Update VaultLockScreen subtitle texts to clearly state that the passphrase
encrypts a master key (not credentials directly), and that the passphrase is
never stored. Add a collapsible "How encryption works" section showing the
full chain: passphrase → scrypt → wrapping key → AES-256-GCM → master key →
AES-256-GCM → credentials.

https://claude.ai/code/session_0156gbeKWWEWv4kWVa5kqa5X