### PR TITLE
security: swap exec() for execFile() in stopAllScrapers

### DIFF
--- a/app/pages/api/utils/scraperUtils.js
+++ b/app/pages/api/utils/scraperUtils.js
@@ -25,10 +25,23 @@ import {
 import { generateTransactionIdentifier } from './transactionUtils.js';
 import { createScraper } from 'israeli-bank-scrapers';
 import logger from '../../../utils/logger.js';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { promisify } from 'util';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
+
+// pkillQuiet replaces `exec("pkill -f '<pattern>' || true")`. Using execFile
+// (argv form, no shell parser) removes the latent shell-injection sink if any
+// caller ever passes a non-literal pattern. Swallows non-zero exit codes to
+// emulate the original `|| true` semantics (pkill returns 1 when no process
+// matches, which is expected here).
+async function pkillQuiet(pattern) {
+  try {
+    await execFileAsync('pkill', ['-f', pattern]);
+  } catch {
+    // no-op: pkill exits non-zero when nothing matches, which is fine.
+  }
+}
 import {
   getChromePath,
   getScraperOptions,
@@ -716,16 +729,16 @@ export async function stopAllScrapers(client) {
   try {
     if (process.platform === 'darwin') {
       // macOS: target Chrome/Chromium with headless or automation flags
-      await execAsync("pkill -f 'Google Chrome.*headless' || true");
-      await execAsync("pkill -f 'Chromium.*headless' || true");
-      await execAsync("pkill -f 'Chrome for Testing.*headless' || true");
-      await execAsync("pkill -f 'Google Chrome.*remote-debugging-port=9223' || true");
-      await execAsync("pkill -f 'Chrome for Testing.*remote-debugging-port=9223' || true");
+      await pkillQuiet('Google Chrome.*headless');
+      await pkillQuiet('Chromium.*headless');
+      await pkillQuiet('Chrome for Testing.*headless');
+      await pkillQuiet('Google Chrome.*remote-debugging-port=9223');
+      await pkillQuiet('Chrome for Testing.*remote-debugging-port=9223');
     } else {
       // Linux/others
-      await execAsync("pkill -f 'chromium.*headless' || true");
-      await execAsync("pkill -f 'chrome.*headless' || true");
-      await execAsync("pkill -f 'Chrome for Testing.*headless' || true");
+      await pkillQuiet('chromium.*headless');
+      await pkillQuiet('chrome.*headless');
+      await pkillQuiet('Chrome for Testing.*headless');
     }
     logger.info('[Scraper Utils] Browser processes killed');
   } catch (err) {


### PR DESCRIPTION
## Summary

Replace `child_process.exec` with `execFile` (argv form, no shell) in `app/pages/api/utils/scraperUtils.js`. Introduces a small `pkillQuiet(pattern)` helper that preserves the existing \`|| true\` semantics via try/catch, and swaps all eight \`pkill\` call sites in \`stopAllScrapers\`.

## Motivation

Discovered during a broader MCP supply-chain audit. **Not an exploitable vulnerability right now** — every existing call site passes a hardcoded string literal, so there is no taint source. Filing as defense-in-depth:

- \`exec()\` invokes a shell; \`execFile()\` does not. The moment any of these patterns become dynamic (process name, debug port, etc.), the shell-parsing variant becomes a command-injection sink.
- pkill pattern arguments are exactly the kind of value that tends to grow dynamic over time as scraper config expands.
- \`execFile\` with argv removes the shell parser entirely, so future callers inherit a safe default.

## Behavior

Identical. \`pkillQuiet\` swallows non-zero exits the same way \`|| true\` did (pkill returns 1 when nothing matches, which is expected).

## Test plan

- [x] \`node --check\` passes
- [x] \`execAsync\` symbol fully removed from the file (grep clean)
- [x] \`stopAllScrapers\` is mocked in \`scraper_endpoints.test.ts\`, so consumers of the exported API see no change
- [ ] Would appreciate maintainer running the full vitest suite

Happy to address any feedback. Thank you for maintaining this project!