### PR TITLE
chore: update israeli-bank-scrapers to 6.7.4

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -25,7 +25,7 @@
         "canvas-confetti": "^1.9.4",
         "date-fns": "^4.1.0",
         "dotenv": "^16.5.0",
-        "israeli-bank-scrapers": "^6.7.3",
+        "israeli-bank-scrapers": "^6.7.4",
         "next": "^16.1.4",
         "next-auth": "^4.24.13",
         "node-cron": "^4.2.1",
@@ -10208,9 +10208,9 @@
       "license": "ISC"
     },
     "node_modules/israeli-bank-scrapers": {
-      "version": "6.7.3",
-      "resolved": "https://registry.npmjs.org/israeli-bank-scrapers/-/israeli-bank-scrapers-6.7.3.tgz",
-      "integrity": "sha512-ZOzfSJNeRx5s95yzr6STZVG6Zz9katy0GCz/af3gsYoinbzk2Bh0Zxfj/++hJnoLuk6ONpl5lCclwU35dRATMg==",
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/israeli-bank-scrapers/-/israeli-bank-scrapers-6.7.4.tgz",
+      "integrity": "sha512-M6aEws/6Pxks8/INtDYCbLPDWeoZLStNF9ulTalUg89pAyFemNznl0SkcniIDqIQIZN/5vhtr79HojgvRpxN5w==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.2",

--- a/app/package.json
+++ b/app/package.json
@@ -36,7 +36,7 @@
     "canvas-confetti": "^1.9.4",
     "date-fns": "^4.1.0",
     "dotenv": "^16.5.0",
-    "israeli-bank-scrapers": "^6.7.3",
+    "israeli-bank-scrapers": "^6.7.4",
     "next": "^16.1.4",
     "next-auth": "^4.24.13",
     "node-cron": "^4.2.1",


### PR DESCRIPTION
## Summary
- Patch bump `israeli-bank-scrapers` 6.7.3 → 6.7.4
- No code changes; lockfile updated

## Test plan
- [x] `npm run test` — 585/585 pass
- [x] `npm run lint` — no new errors (pre-existing warnings only)
- [ ] Manual scrape sanity-check before merging if desired