### PR TITLE
fix(whatsapp): tear down failed client and clean session locks before retrying

### DIFF
--- a/app/tests/whatsapp-client.test.ts
+++ b/app/tests/whatsapp-client.test.ts
@@ -3,7 +3,6 @@ import pkg from 'whatsapp-web.js';
 import { getClient, getOrCreateClient, initializeClient, getStatus, destroyClient, restartClient, hasPersistedSession, clearSession, renewQrCode } from '../utils/whatsapp-client.js';
 import logger from '../utils/logger.js';
 import fs from 'fs';
-import path from 'path';
 
 // Mock whatsapp-web.js
 vi.mock('whatsapp-web.js', () => {
@@ -94,55 +93,67 @@ describe('WhatsApp Client Utils', () => {
             expect(pkg.Client).toHaveBeenCalledTimes(1);
         });
 
-        it('should handle initialization failure and retry', async () => {
-            const mockClient = {
+        it('should destroy the failed client, clean session locks, and retry with a fresh client', async () => {
+            const failingClient = {
                 on: vi.fn(),
-                initialize: vi.fn()
-                    .mockRejectedValueOnce(new Error('Init failed 1'))
-                    .mockRejectedValueOnce(new Error('Init failed 2'))
-                    .mockResolvedValueOnce(undefined),
-                destroy: vi.fn(),
+                initialize: vi.fn().mockRejectedValueOnce(new Error('Init failed 1')),
+                destroy: vi.fn().mockResolvedValue(undefined),
             };
-            (pkg.Client as any).mockReturnValueOnce(mockClient);
+            const successClient = {
+                on: vi.fn(),
+                initialize: vi.fn().mockResolvedValueOnce(undefined),
+                destroy: vi.fn().mockResolvedValue(undefined),
+            };
+            (pkg.Client as any)
+                .mockReturnValueOnce(failingClient)
+                .mockReturnValueOnce(successClient);
+            (fs.existsSync as any).mockReturnValue(true);
 
             initializeClient();
 
-            // Process first failure logic
+            // Process the first failure
+            await vi.runOnlyPendingTimersAsync();
+            // Advance past the 2s backoff before the retry
+            await vi.advanceTimersByTimeAsync(2000);
             await vi.runOnlyPendingTimersAsync();
 
-            // Advance time for first retry (2s)
-            await vi.advanceTimersByTimeAsync(2000);
+            // First client was tried exactly once and then destroyed for cleanup
+            expect(failingClient.initialize).toHaveBeenCalledTimes(1);
+            expect(failingClient.destroy).toHaveBeenCalledTimes(1);
 
-            // Advance time for second retry (4s)
-            await vi.advanceTimersByTimeAsync(4000);
+            // Stale Chromium session locks are cleaned between attempts
+            expect(fs.unlinkSync).toHaveBeenCalled();
 
-            expect(mockClient.initialize).toHaveBeenCalledTimes(3);
+            // The retry uses a brand new client (initialize() is single-use per instance)
+            expect(pkg.Client).toHaveBeenCalledTimes(2);
+            expect(successClient.initialize).toHaveBeenCalledTimes(1);
+
             expect(logger.error).toHaveBeenCalledWith(
                 expect.objectContaining({ err: 'Init failed 1', retry: 1 }),
                 expect.any(String)
             );
         });
 
-        it('should recover from SingletonLock error', async () => {
-            const mockClient = {
+        it('should remove stale Singleton lock files when init fails', async () => {
+            const failingClient = {
                 on: vi.fn(),
-                initialize: vi.fn()
-                    .mockRejectedValueOnce(new Error('SingletonLock'))
-                    .mockResolvedValueOnce(undefined),
-                destroy: vi.fn(),
+                initialize: vi.fn().mockRejectedValueOnce(new Error('SingletonLock')),
+                destroy: vi.fn().mockResolvedValue(undefined),
             };
-            (pkg.Client as any).mockReturnValueOnce(mockClient);
+            (pkg.Client as any).mockReturnValueOnce(failingClient);
             (fs.existsSync as any).mockReturnValue(true);
 
             initializeClient();
 
-            // Process lock recovery logic
             await vi.runOnlyPendingTimersAsync();
             await vi.advanceTimersByTimeAsync(2000);
+            await vi.runOnlyPendingTimersAsync();
 
-            expect(fs.unlinkSync).toHaveBeenCalled();
-            expect(mockClient.initialize).toHaveBeenCalledTimes(2);
-            expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('SingletonLock'));
+            expect(failingClient.destroy).toHaveBeenCalled();
+            const unlinkedPaths = (fs.unlinkSync as any).mock.calls.map((c: any[]) => c[0] as string);
+            expect(unlinkedPaths.some((p) => p.includes('SingletonLock'))).toBe(true);
+            expect(unlinkedPaths.some((p) => p.includes('SingletonCookie'))).toBe(true);
+            expect(unlinkedPaths.some((p) => p.includes('SingletonSocket'))).toBe(true);
         });
     });
 

--- a/app/utils/whatsapp-client.js
+++ b/app/utils/whatsapp-client.js
@@ -74,6 +74,91 @@ export function getOrCreateClient() {
 }
 
 /**
+ * Build a fresh whatsapp-web.js Client configured with our LocalAuth and
+ * puppeteer settings. Pulled out so retries can construct a new instance —
+ * Client.initialize() is single-use, calling it twice on the same object
+ * leaves the previous chromium subprocess holding the userDataDir lock.
+ */
+function buildClient() {
+    // NOTE: --single-process is NOT used here as it causes "detached Frame" errors with WhatsApp Web's iframes
+    const browserArgs = getWhatsappChromeArgs();
+    return new Client({
+        authStrategy: new LocalAuth({
+            clientId: CLIENT_ID,
+            dataPath: AUTH_PATH
+        }),
+        puppeteer: {
+            headless: true,
+            // Use system chromium if available (Crucial for Docker)
+            executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || undefined,
+            args: browserArgs,
+            pipe: true
+        }
+    });
+}
+
+function wireClientEvents(client) {
+    client.on('qr', (qr) => {
+        logger.info('WhatsApp QR Code generated');
+        qrCode = qr;
+        connectionStatus = 'QR_READY';
+        globalAny.whatsappQR = qr;
+        globalAny.whatsappStatus = 'QR_READY';
+    });
+
+    client.on('ready', () => {
+        logger.info('WhatsApp Client is ready!');
+        connectionStatus = 'READY';
+        qrCode = null;
+        globalAny.whatsappQR = null;
+        globalAny.whatsappStatus = 'READY';
+    });
+
+    client.on('authenticated', () => {
+        logger.info('WhatsApp Client authenticated');
+        connectionStatus = 'AUTHENTICATED';
+        globalAny.whatsappStatus = 'AUTHENTICATED';
+    });
+
+    client.on('auth_failure', (msg) => {
+        logger.error({ msg }, 'WhatsApp authentication failure');
+        connectionStatus = 'DISCONNECTED';
+        globalAny.whatsappStatus = 'DISCONNECTED';
+    });
+
+    client.on('disconnected', async (reason) => {
+        logger.warn({ reason }, 'WhatsApp Client disconnected');
+        connectionStatus = 'DISCONNECTED';
+        qrCode = null;
+        globalAny.whatsappQR = null;
+        globalAny.whatsappStatus = 'DISCONNECTED';
+
+        // Clean up and allow for re-initialization
+        await destroyClient();
+    });
+}
+
+/**
+ * Remove stale Chromium singleton lock files left behind by a previous
+ * Client.initialize() that crashed before puppeteer could close the browser.
+ * If we don't, the next initialize() fails with "browser is already running".
+ */
+function cleanupSessionLocks() {
+    const lockNames = ['SingletonLock', 'SingletonCookie', 'SingletonSocket'];
+    for (const name of lockNames) {
+        const lockPath = path.join(SESSION_PATH, name);
+        try {
+            if (fs.existsSync(lockPath)) {
+                fs.unlinkSync(lockPath);
+                logger.info({ lockFile: name }, 'Removed stale WhatsApp session lock');
+            }
+        } catch (err) {
+            logger.warn({ err: err.message, lockFile: name }, 'Failed to remove WhatsApp session lock');
+        }
+    }
+}
+
+/**
  * Initialize the WhatsApp client on-demand.
  * This creates a new client and starts the authentication process.
  * If a persisted session exists, it will be restored automatically.
@@ -89,63 +174,8 @@ export function initializeClient() {
     const hasSession = hasPersistedSession();
     logger.info({ hasPersistedSession: hasSession }, 'Initializing new WhatsApp Client instance...');
 
-    // Build browser args from centralized resource config
-    // NOTE: --single-process is NOT used here as it causes "detached Frame" errors with WhatsApp Web's iframes
-    const browserArgs = getWhatsappChromeArgs();
-
-    clientInstance = new Client({
-        authStrategy: new LocalAuth({
-            clientId: CLIENT_ID,
-            dataPath: AUTH_PATH
-        }),
-        puppeteer: {
-            headless: true,
-            // Use system chromium if available (Crucial for Docker)
-            executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || undefined,
-            args: browserArgs,
-            pipe: true
-        }
-    });
-
-    // Event listeners
-    clientInstance.on('qr', (qr) => {
-        logger.info('WhatsApp QR Code generated');
-        qrCode = qr;
-        connectionStatus = 'QR_READY';
-        globalAny.whatsappQR = qr;
-        globalAny.whatsappStatus = 'QR_READY';
-    });
-
-    clientInstance.on('ready', () => {
-        logger.info('WhatsApp Client is ready!');
-        connectionStatus = 'READY';
-        qrCode = null;
-        globalAny.whatsappQR = null;
-        globalAny.whatsappStatus = 'READY';
-    });
-
-    clientInstance.on('authenticated', () => {
-        logger.info('WhatsApp Client authenticated');
-        connectionStatus = 'AUTHENTICATED';
-        globalAny.whatsappStatus = 'AUTHENTICATED';
-    });
-
-    clientInstance.on('auth_failure', (msg) => {
-        logger.error({ msg }, 'WhatsApp authentication failure');
-        connectionStatus = 'DISCONNECTED';
-        globalAny.whatsappStatus = 'DISCONNECTED';
-    });
-
-    clientInstance.on('disconnected', async (reason) => {
-        logger.warn({ reason }, 'WhatsApp Client disconnected');
-        connectionStatus = 'DISCONNECTED';
-        qrCode = null;
-        globalAny.whatsappQR = null;
-        globalAny.whatsappStatus = 'DISCONNECTED';
-
-        // Clean up and allow for re-initialization
-        await destroyClient();
-    });
+    clientInstance = buildClient();
+    wireClientEvents(clientInstance);
 
     // Save to global to survive HMR
     globalAny.whatsappClient = clientInstance;
@@ -165,34 +195,35 @@ export function initializeClient() {
             initRetries++;
             logger.error({ err: err.message, retry: initRetries }, 'Failed to initialize WhatsApp client');
 
-            // Specialized recovery for Puppeteer SingletonLock
-            if (err.message && (err.message.includes('SingletonLock') || err.message.includes('profile appears to be in use'))) {
-                logger.warn('Detected SingletonLock error, attempting automatic cleanup...');
-                try {
-                    const lockPath = path.join(SESSION_PATH, 'SingletonLock');
-                    if (fs.existsSync(lockPath)) {
-                        fs.unlinkSync(lockPath);
-                        logger.info('Removed SingletonLock file, retrying...');
-                        await new Promise(resolve => setTimeout(resolve, 1000));
-                        return initializeWithRetry();
-                    }
-                } catch (retryErr) {
-                    logger.error({ err: retryErr.message }, 'Failed to recover from SingletonLock');
-                }
-            }
-
-            if (initRetries < MAX_INIT_RETRIES) {
-                const delay = Math.pow(2, initRetries) * 1000;
-                await new Promise(resolve => setTimeout(resolve, delay));
-                return initializeWithRetry();
-            } else {
+            if (initRetries >= MAX_INIT_RETRIES) {
                 logger.error('Max retries reached for WhatsApp initialization');
                 connectionStatus = 'DISCONNECTED';
                 globalAny.whatsappStatus = 'DISCONNECTED';
                 // Reset client so it can be re-tried manually later
                 clientInstance = null;
                 globalAny.whatsappClient = null;
+                return;
             }
+
+            // The previous attempt may have left a chromium subprocess alive
+            // holding the userDataDir lock. Tear it down before retrying.
+            try {
+                await clientInstance.destroy();
+            } catch (destroyErr) {
+                logger.warn({ err: destroyErr.message }, 'Could not destroy failed WhatsApp client; continuing cleanup');
+            }
+            cleanupSessionLocks();
+
+            // Backoff so chromium has time to actually exit and release the lock
+            const delay = Math.pow(2, initRetries) * 1000;
+            await new Promise(resolve => setTimeout(resolve, delay));
+
+            // Client.initialize() is single-use per instance; build a fresh one
+            clientInstance = buildClient();
+            wireClientEvents(clientInstance);
+            globalAny.whatsappClient = clientInstance;
+
+            return initializeWithRetry();
         }
     };
 


### PR DESCRIPTION
## Summary

WhatsApp client init currently fails permanently after the first error because the retry handler never tears down the previous attempt. The chromium subprocess from try #1 is left alive holding the `userDataDir` lock, so tries #2 and #3 fail with `The browser is already running for /app/.wwebjs_auth/session-nudlers-client`, max retries are reached, and the WhatsApp subsystem ends up `DISCONNECTED` until the container is restarted.

This is exactly the cascade observed in production logs:
```
retry 1: Execution context was destroyed.
retry 2: The browser is already running for ... Use a different `userDataDir` or stop the running browser first.
retry 3: The browser is already running for ...
Max retries reached for WhatsApp initialization
```

## Root cause

- `Client.initialize()` is single-use per `Client` instance — calling it twice on the same object can't recover from a failed first attempt.
- The previous code only had a SingletonLock-text-match branch that *sometimes* deleted one lock file. It never destroyed the existing client, never killed the orphaned chromium, and never cleaned `SingletonCookie`/`SingletonSocket`.

## Fix

- Extract `buildClient()` and `wireClientEvents()` so retries can create a fresh, non-tainted instance.
- Extract `cleanupSessionLocks()` covering `SingletonLock`, `SingletonCookie`, `SingletonSocket` (chromium creates all three; removing only one isn't enough).
- On any init failure (not just SingletonLock text matches): `await client.destroy().catch(...)` to release chromium → `cleanupSessionLocks()` → existing exponential backoff so chromium fully exits → `buildClient()` + `wireClientEvents()` → retry. Drops the now-redundant SingletonLock-specific branch.

## Tests

- `should destroy the failed client, clean session locks, and retry with a fresh client` — verifies `destroy` is called on the failed client, `fs.unlinkSync` is called for the lock files, a new `Client` is constructed for the retry, and the retry succeeds.
- `should remove stale Singleton lock files when init fails` — verifies all three lock filenames (`SingletonLock`, `SingletonCookie`, `SingletonSocket`) are unlinked.

## Out of scope (separate work)

- Moving `autoRestoreSession()` off module top-level (currently runs as an import side-effect at line 320 of `whatsapp-client.js`). Worth doing eventually but a bigger surface change.
- Memory tuning for low-resource NAS deploys (the underlying `Execution context was destroyed` error is most likely chromium OOM).

## Test plan

- [x] `npm run test` — 585/585 pass
- [x] `npm run lint` — clean on touched files
- [ ] Deploy on NAS, watch a startup cycle: on the next chromium hiccup the logs should now show `Removed stale WhatsApp session lock` per file then a successful retry, instead of the "browser is already running" loop.