### PR TITLE
fix(background-sync): align encryption import path to share VaultStore singleton

### DIFF
--- a/app/scripts/background-sync.js
+++ b/app/scripts/background-sync.js
@@ -1,6 +1,6 @@
 import { Pool } from 'pg';
 import logger from '../utils/logger.js';
-import { decrypt } from '../pages/api/utils/encryption.js';
+import { decrypt } from '../pages/api/utils/encryption';
 import {
     prepareCredentials,
     validateCredentials,


### PR DESCRIPTION
## Summary
- The cron-driven background sync has been failing every tick with `VaultLockedError` even when the vault was unlocked through the UI/passkey flow. Root cause: `app/scripts/background-sync.js` was the only site importing `encryption` with a `.js` extension; Turbopack's production build treated `'./encryption'` and `'./encryption.js'` as distinct specifiers and emitted two parallel `encryption` modules, each with its own `VaultStore` singleton. Unlock writes the master key into the singleton used by API routes (module id `31452`), while the cron read from a parallel singleton (`66058`) that nothing ever populated.
- Fix is a one-character change: drop the `.js` so the cron resolves through the same module instance the rest of the app uses.

## Test plan
- [ ] Rebuild the standalone bundle and confirm only one `VaultStore` module id appears (`grep -oE 'masterKey=null,this\._initialized=!1' app/.next/standalone/app/.next/server/chunks/*.js | sort -u`).
- [ ] On a deployed container, unlock the vault, wait for the next `sync_hour` tick, and confirm `[Background Sync]` completes without `Vault is locked`.
- [ ] Existing test suite still green (`npm run test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)