### PR TITLE
perf(api): dedupe billing_cycle_start_day lookups across endpoints

### DIFF
--- a/app/pages/api/reports/budget-vs-actual.js
+++ b/app/pages/api/reports/budget-vs-actual.js
@@ -3,6 +3,7 @@ import logger from '../../../utils/logger.js';
 import { BANK_VENDORS } from '../../../utils/constants.js';
 
 import { getBillingCycleSql } from "../../../utils/transaction_logic";
+import { getBillingCycleStartDay } from "../utils/scraperUtils";
 
 // Ensure the total_budget table exists
 async function ensureTotalBudgetTable(client) {
@@ -37,12 +38,7 @@ export default async function handler(req, res) {
     await ensureTotalBudgetTable(client);
 
     // Get billing start day setting
-    const settingsResult = await client.query(
-      "SELECT value FROM app_settings WHERE key = 'billing_cycle_start_day'"
-    );
-    const billingStartDay = settingsResult.rows.length > 0
-      ? (parseInt(settingsResult.rows[0].value, 10) || 10)
-      : 10;
+    const billingStartDay = await getBillingCycleStartDay(client);
 
     let actualSpendingSql;
     let actualParams;

--- a/app/pages/api/reports/monthly-summary.js
+++ b/app/pages/api/reports/monthly-summary.js
@@ -1,10 +1,10 @@
 import { createApiHandler } from "../utils/apiHandler";
-import { getDB } from "../db";
 import { getBillingCycleSql } from "../../../utils/transaction_logic";
+import { getBillingCycleStartDay } from "../utils/scraperUtils";
 import { BANK_VENDORS } from "../../../utils/constants";
 
 const handler = createApiHandler({
-  query: async (req) => {
+  query: async (req, client) => {
     const {
       startDate, endDate, vendor, groupBy, billingCycle,
       excludeBankTransactions, limit = 50, offset = 0,
@@ -36,20 +36,7 @@ const handler = createApiHandler({
     let paramIndex = 1;
 
     if (billingCycle) {
-      const client = await getDB();
-      let billingStartDay = 10;
-      try {
-        const settingsResult = await client.query("SELECT value FROM app_settings WHERE key = 'billing_cycle_start_day'");
-        if (settingsResult.rows.length > 0) {
-          const val = parseInt(settingsResult.rows[0].value, 10);
-          if (!isNaN(val)) {
-            billingStartDay = val;
-          }
-        }
-      } finally {
-        client.release();
-      }
-
+      const billingStartDay = await getBillingCycleStartDay(client);
       const effectiveMonthSql = getBillingCycleSql(billingStartDay, 't.date', 't.processed_date');
       whereClause = `WHERE (${effectiveMonthSql}) = $${paramIndex}`;
       params.push(billingCycle);

--- a/app/pages/api/transactions/index.js
+++ b/app/pages/api/transactions/index.js
@@ -2,6 +2,7 @@ import { createApiHandler } from "../utils/apiHandler";
 import { decrypt } from "../utils/encryption";
 import { getDB } from "../db";
 import { getBillingCycleSql } from "../../../utils/transaction_logic";
+import { getBillingCycleStartDay } from "../utils/scraperUtils";
 import { BANK_VENDORS } from "../../../utils/constants";
 import logger from '../../../utils/logger.js';
 
@@ -120,7 +121,7 @@ const getTransactions = createApiHandler({
             return "Time filter (billingCycle or startDate/endDate) is required unless searching or filtering by uncategorized";
         }
     },
-    query: async (req) => {
+    query: async (req, client) => {
         const {
             q,
             startDate,
@@ -159,18 +160,7 @@ const getTransactions = createApiHandler({
         }
 
         if (availableMonths === 'true') {
-            let billingStartDay = 10;
-            const client = await getDB();
-            try {
-                const settingsResult = await client.query("SELECT value FROM app_settings WHERE key = 'billing_cycle_start_day'");
-                if (settingsResult.rows.length > 0) {
-                    const parsed = parseInt(settingsResult.rows[0].value, 10);
-                    if (!isNaN(parsed)) billingStartDay = parsed;
-                }
-            } finally {
-                client.release();
-            }
-
+            const billingStartDay = await getBillingCycleStartDay(client);
             const cycleSql = getBillingCycleSql(billingStartDay, 'date', 'processed_date');
             return {
                 sql: `SELECT ARRAY_AGG(DISTINCT ${cycleSql}) as months FROM transactions;`,
@@ -183,17 +173,7 @@ const getTransactions = createApiHandler({
 
         // 1. Time Filtering (Billing Cycle or Date Range)
         if (billingCycle) {
-            let billingStartDay = 10;
-            const client = await getDB();
-            try {
-                const settingsResult = await client.query("SELECT value FROM app_settings WHERE key = 'billing_cycle_start_day'");
-                if (settingsResult.rows.length > 0) {
-                    const parsed = parseInt(settingsResult.rows[0].value, 10);
-                    if (!isNaN(parsed)) billingStartDay = parsed;
-                }
-            } finally {
-                client.release();
-            }
+            const billingStartDay = await getBillingCycleStartDay(client);
             const effectiveMonthSql = getBillingCycleSql(billingStartDay, 't.date', 't.processed_date');
             conditions.push(`(${effectiveMonthSql}) = $${paramIndex}`);
             params.push(billingCycle);

--- a/app/pages/api/utils/apiHandler.js
+++ b/app/pages/api/utils/apiHandler.js
@@ -22,7 +22,7 @@ export function createApiHandler({ query, validate, transform }) {
         }
       }
 
-      const { sql, params = [] } = await query(req);
+      const { sql, params = [] } = await query(req, client);
       const result = await client.query(sql, params);
       const data = transform ? await transform(result, req) : result.rows;
 


### PR DESCRIPTION
## Summary
- Four endpoints (`/api/transactions` list & availableMonths, `/api/reports/budget-vs-actual`, `/api/reports/monthly-summary`) inlined the same `app_settings` lookup for `billing_cycle_start_day`. Two of them opened a second DB connection per request just for that one-row read.
- Replace all four with the existing `getBillingCycleStartDay` helper from `pages/api/utils/scraperUtils`.
- Extend `createApiHandler` to pass the open `client` into the `query` callback so callers can reuse it for prep work (backward compatible — existing callbacks ignoring the second arg are unaffected).

Net: -37 lines, -2 pool checkouts per affected request, single source of truth for the setting read.

## Test plan
- [x] `npm run test -- --run transactions apiHandler monthly_summary budget_vs_actual` (50 pass)
- [x] `npm run lint` (no new findings on touched files)
- [ ] Smoke: open transactions view with a billingCycle filter
- [ ] Smoke: open monthly summary report
- [ ] Smoke: open budget-vs-actual report

🤖 Generated with [Claude Code](https://claude.com/claude-code)