### PR TITLE
perf(categories): kill N+1 in CategoryManagementModal

### DIFF
--- a/app/components/CategoryDashboard/components/CategoryManagementModal.tsx
+++ b/app/components/CategoryDashboard/components/CategoryManagementModal.tsx
@@ -283,36 +283,14 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
     try {
       setIsLoading(true);
       setError(null);
-      const response = await fetch('/api/categories');
+      const response = await fetch('/api/categories?withCounts=true');
       if (!response.ok) {
         const errorText = await response.text().catch(() => 'Unknown error');
         const errorMessage = `Failed to fetch categories: ${response.status} ${response.statusText}${errorText ? ` - ${errorText}` : ''}`;
         throw new Error(errorMessage);
       }
 
-      const categoryNames = await response.json();
-
-      // Get transaction counts for each category
-      const categoriesWithCounts = await Promise.all(
-        categoryNames.map(async (name: string) => {
-          try {
-            const countResponse = await fetch(`/api/transactions?category=${encodeURIComponent(name)}`);
-            if (!countResponse.ok) {
-              logger.warn(`Failed to fetch count for category "${name}": ${countResponse.status}`);
-              return { name, count: 0 };
-            }
-            const transactions = await countResponse.json();
-            return {
-              name,
-              count: Array.isArray(transactions) ? transactions.length : 0
-            };
-          } catch (err) {
-            logger.warn(`Error fetching count for category "${name}": ${err instanceof Error ? err.message : 'Unknown error'}`);
-            return { name, count: 0 };
-          }
-        })
-      );
-
+      const categoriesWithCounts: Category[] = await response.json();
       setCategories(categoriesWithCounts.sort((a, b) => a.name.localeCompare(b.name, 'he')));
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';

--- a/app/pages/api/categories/index.js
+++ b/app/pages/api/categories/index.js
@@ -10,7 +10,15 @@ const handler = createApiHandler({
       ORDER BY count DESC
     `
     }),
-    transform: (result) => result.rows.map((row) => row.name)
+    transform: (result, req) => {
+        if (req.query.withCounts === 'true') {
+            return result.rows.map((row) => ({
+                name: row.name,
+                count: parseInt(row.count, 10) || 0,
+            }));
+        }
+        return result.rows.map((row) => row.name);
+    }
 });
 
 export default handler;

--- a/app/tests/categories_api.test.ts
+++ b/app/tests/categories_api.test.ts
@@ -56,6 +56,22 @@ describe('Categories List API (/api/categories)', () => {
 
         expect(mockRes.json).toHaveBeenCalledWith([]);
     });
+
+    it('should return {name,count} objects when withCounts=true', async () => {
+        mockClient.query.mockResolvedValue({
+            rows: [
+                { name: 'Food', count: '50' },
+                { name: 'Transport', count: '30' }
+            ]
+        });
+
+        await categoriesHandler({ method: 'GET', query: { withCounts: 'true' } } as any, mockRes as any);
+
+        expect(mockRes.json).toHaveBeenCalledWith([
+            { name: 'Food', count: 50 },
+            { name: 'Transport', count: 30 }
+        ]);
+    });
 });
 
 describe('Category by Name API (/api/categories/[name])', () => {


### PR DESCRIPTION
## Summary
- Opening the Category Management modal fired 1 + N HTTP requests: `GET /api/categories` (names) followed by one `GET /api/transactions?category=...` per category just to count rows. With 50 categories that's 51 round-trips per modal open.
- The `/api/categories` SQL already does `COUNT(*) ... GROUP BY category`; the `transform` was throwing the count away.
- Add opt-in `?withCounts=true` so the endpoint returns `{name, count}[]`. Default response (string array) is unchanged so the six other callers (`BudgetDashboard`, `BudgetModule`, `QuickCategoryModal`, `ProjectionView`, `useCategories`, `categoryUtils`) continue working as-is.
- Modal switches to `withCounts=true` and drops the fan-out.

Net: 1 request instead of 1 + N on modal open, no breaking change to other consumers.

## Test plan
- [x] `npm run test -- --run categories_api` (29 pass, +1 new for `withCounts=true`)
- [ ] Smoke: open Category Management modal — counts render, no waterfall in network tab
- [ ] Smoke: BudgetDashboard / BudgetModule / QuickCategoryModal / ProjectionView still load categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)