### PR TITLE
feat(onezero): native 2FA + provider-agnostic error classifier

### DIFF
--- a/app/components/AccountsView.tsx
+++ b/app/components/AccountsView.tsx
@@ -41,6 +41,8 @@ interface Account {
     id_number?: string;
     card6_digits?: string;
     bank_account_number?: string;
+    phone_number?: string;
+    has_otp_long_term_token?: boolean;
     nickname?: string;
     is_active: boolean;
     created_at?: string;
@@ -77,6 +79,7 @@ const AccountsView: React.FC = () => {
         id_number: '',
         card6_digits: '',
         bank_account_number: '',
+        phone_number: '',
         password: '',
         nickname: '',
         id: 0,
@@ -259,6 +262,7 @@ const AccountsView: React.FC = () => {
             id_number: account.id_number || '',
             card6_digits: account.card6_digits || '',
             bank_account_number: account.bank_account_number || '',
+            phone_number: account.phone_number || '',
             password: '',
             nickname: account.nickname || '',
             id: account.id,
@@ -273,6 +277,7 @@ const AccountsView: React.FC = () => {
             id_number: '',
             card6_digits: '',
             bank_account_number: '',
+            phone_number: '',
             password: '',
             nickname: '',
             id: 0,
@@ -451,7 +456,25 @@ const AccountsView: React.FC = () => {
                             ))}
                         </TextField>
 
-                        {(formAccount.vendor === 'visaCal' || formAccount.vendor === 'max' || BANK_VENDORS.includes(formAccount.vendor)) ? (
+                        {formAccount.vendor === 'onezero' ? (
+                            <>
+                                <TextField
+                                    fullWidth
+                                    type="email"
+                                    label="Email"
+                                    value={formAccount.username}
+                                    onChange={(e) => setFormAccount({ ...formAccount, username: e.target.value })}
+                                />
+                                <TextField
+                                    fullWidth
+                                    label="Phone Number (e.g. +972501234567)"
+                                    placeholder="+972501234567"
+                                    value={formAccount.phone_number}
+                                    onChange={(e) => setFormAccount({ ...formAccount, phone_number: e.target.value })}
+                                    helperText="Used to send a one-time SMS code on first sync; subsequent syncs reuse a long-term token."
+                                />
+                            </>
+                        ) : (formAccount.vendor === 'visaCal' || formAccount.vendor === 'max' || BANK_VENDORS.includes(formAccount.vendor)) ? (
                             <TextField
                                 fullWidth
                                 label="Username / ID"
@@ -475,7 +498,7 @@ const AccountsView: React.FC = () => {
                             </Box>
                         )}
 
-                        {STANDARD_BANK_VENDORS.includes(formAccount.vendor) && (
+                        {STANDARD_BANK_VENDORS.includes(formAccount.vendor) && formAccount.vendor !== 'onezero' && (
                             <TextField
                                 fullWidth
                                 label="Account Number"

--- a/app/components/SyncStatusModal.tsx
+++ b/app/components/SyncStatusModal.tsx
@@ -44,6 +44,20 @@ import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import SendIcon from '@mui/icons-material/Send';
 
+// Tag thrown by SSE 'error' handler so the outer catch can recognise an expected,
+// already-classified failure (e.g. INVALID_CREDENTIALS) and log it quietly instead
+// of emitting a console.error + raw Error stack trace.
+class KnownSyncFailure extends Error {
+  readonly type: string;
+  readonly originalMessage: string | null;
+  constructor(type: string, message: string, originalMessage: string | null) {
+    super(message);
+    this.name = 'KnownSyncFailure';
+    this.type = type;
+    this.originalMessage = originalMessage;
+  }
+}
+
 interface SyncStatusModalProps {
   open: boolean;
   onClose: () => void;
@@ -511,6 +525,7 @@ const SyncStatusModal: React.FC<SyncStatusModalProps> = ({ open, onClose, width,
     id_number?: string;
     bank_account_number?: string;
     card6_digits?: string;
+    phone_number?: string;
   }
 
   const prepareCredentials = (account: SyncAccountCredentials, vendor: string) => {
@@ -533,6 +548,14 @@ const SyncStatusModal: React.FC<SyncStatusModalProps> = ({ open, onClose, width,
       return {
         userCode: String(userCode),
         password: String(account.password || '')
+      };
+    } else if (vendor === 'onezero') {
+      // OneZero: email lives in the username column. The long-term OTP token is loaded
+      // server-side from the DB by credentialId — never sent through the browser.
+      return {
+        email: String(account.username || ''),
+        password: String(account.password || ''),
+        phoneNumber: String(account.phone_number || '')
       };
     } else if (BANK_VENDORS.includes(vendor)) {
       const bankId = account.username || account.id_number || '';
@@ -746,15 +769,25 @@ const SyncStatusModal: React.FC<SyncStatusModalProps> = ({ open, onClose, width,
                     onClose();
                     return;
                   }
-                  const errorWithHint = eventData.hint ? `${eventData.message}\n\n💡 Hint: ${eventData.hint}` : eventData.message;
-                  throw new Error(errorWithHint);
+                  throw new KnownSyncFailure(
+                    eventData.type || 'UNKNOWN',
+                    eventData.message || eventData.originalMessage || 'Sync failed',
+                    eventData.originalMessage || null,
+                  );
               }
             }
           }
         }
       } catch (err) {
         if (err instanceof Error && err.name === 'AbortError') return;
-        logger.error('Batch sync failed', err);
+        if (err instanceof KnownSyncFailure) {
+          logger.warn(`Sync failed: ${err.message}`, { type: err.type, originalMessage: err.originalMessage });
+          setSyncQueue(prev => prev.map(item =>
+            item.status === 'active' ? { ...item, status: 'failed', error: err.message } : item
+          ));
+        } else {
+          logger.error('Batch sync failed', err);
+        }
         setIsSyncing(false);
         setSyncProgress(null);
         setSyncStartTime(null);
@@ -947,7 +980,16 @@ const SyncStatusModal: React.FC<SyncStatusModalProps> = ({ open, onClose, width,
                     }
                   }));
                 } else if (currentEvent === 'error') {
-                  throw new Error(eventData.message || 'Sync failed');
+                  if (eventData.type === 'VAULT_LOCKED') {
+                    setIsVaultModalOpen(true);
+                    onClose();
+                    return;
+                  }
+                  throw new KnownSyncFailure(
+                    eventData.type || 'UNKNOWN',
+                    eventData.message || eventData.originalMessage || 'Sync failed',
+                    eventData.originalMessage || null,
+                  );
                 } else if (currentEvent === 'complete') {
                   const finalSummary = eventData.summary || {};
                   const finalDuration = finalSummary.durationSeconds ?? (syncStartTime ? Math.floor((Date.now() - syncStartTime) / 1000) : elapsedSeconds);
@@ -1004,7 +1046,11 @@ const SyncStatusModal: React.FC<SyncStatusModalProps> = ({ open, onClose, width,
           setSyncProgress(null);
           return;
         }
-        logger.error('Failed to sync account', err, { account: account.nickname || account.vendor });
+        if (err instanceof KnownSyncFailure) {
+          logger.warn(`Sync failed: ${err.message}`, { account: account.nickname || account.vendor, type: err.type, originalMessage: err.originalMessage });
+        } else {
+          logger.error('Failed to sync account', err, { account: account.nickname || account.vendor });
+        }
         setSyncQueue(prev => prev.map(item =>
           item.id === account.id ? { ...item, status: 'failed', error: err instanceof Error ? err.message : String(err) } : item
         ));

--- a/app/migrations/011_onezero_2fa.sql
+++ b/app/migrations/011_onezero_2fa.sql
@@ -1,0 +1,14 @@
+-- OneZero (and future native-2FA banks): phone number + persistent OTP token.
+-- Both columns hold ciphertext (IV:CT:TAG) produced by utils/encryption.js.
+-- TEXT, not VARCHAR(100), because OTP long-term tokens are JWT-like and exceed 100 chars.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'vendor_credentials' AND column_name = 'phone_number') THEN
+    ALTER TABLE vendor_credentials ADD COLUMN phone_number TEXT;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'vendor_credentials' AND column_name = 'otp_long_term_token') THEN
+    ALTER TABLE vendor_credentials ADD COLUMN otp_long_term_token TEXT;
+  END IF;
+END $$;

--- a/app/pages/api/credentials/[id].js
+++ b/app/pages/api/credentials/[id].js
@@ -48,7 +48,7 @@ const innerHandler = createApiHandler({
 
     // PUT method - full account update
     if (req.method === 'PUT') {
-      const { vendor, username, password, id_number, card6_digits, nickname, bank_account_number } = req.body;
+      const { vendor, username, password, id_number, card6_digits, nickname, bank_account_number, phone_number } = req.body;
 
       // Build dynamic update query based on provided fields
       const updates = ['vendor = $2', 'nickname = $3', 'updated_at = CURRENT_TIMESTAMP'];
@@ -72,11 +72,17 @@ const innerHandler = createApiHandler({
       params.push(bank_account_number || null);
       paramIndex++;
 
-      // Only update password if provided (allows keeping existing password)
+      updates.push(`phone_number = $${paramIndex}`);
+      params.push(phone_number ? encrypt(phone_number) : null);
+      paramIndex++;
+
+      // Only update password if provided (allows keeping existing password).
+      // Password change invalidates any cached long-term OTP token — clear it so the user re-does 2FA.
       if (password) {
         updates.push(`password = $${paramIndex}`);
         params.push(encrypt(password));
         paramIndex++;
+        updates.push('otp_long_term_token = NULL');
       }
 
       return {
@@ -119,6 +125,9 @@ const innerHandler = createApiHandler({
         card6_digits: row.card6_digits ? safeDecrypt(row.card6_digits) : null,
         nickname: row.nickname,
         bank_account_number: row.bank_account_number,
+        phone_number: row.phone_number ? safeDecrypt(row.phone_number) : null,
+        // SECURITY: never return otp_long_term_token; expose only its presence
+        has_otp_long_term_token: !!row.otp_long_term_token,
         is_active: row.is_active !== false,
         created_at: row.created_at
       };

--- a/app/pages/api/credentials/index.js
+++ b/app/pages/api/credentials/index.js
@@ -29,9 +29,9 @@ const handler = createApiHandler({
         };
       }
       if (req.method === 'POST') {
-        const { vendor, username, password, id_number, card6_digits, nickname, bank_account_number } = req.body;
+        const { vendor, username, password, id_number, card6_digits, nickname, bank_account_number, phone_number } = req.body;
 
-        // Encrypt sensitive data
+        // Encrypt sensitive data. otp_long_term_token is server-managed only — never accepted from clients.
         const encryptedData = {
           vendor,
           username: username ? encrypt(username) : null,
@@ -39,13 +39,14 @@ const handler = createApiHandler({
           id_number: id_number ? encrypt(id_number) : null,
           card6_digits: card6_digits ? encrypt(card6_digits) : null,
           nickname,
-          bank_account_number
+          bank_account_number,
+          phone_number: phone_number ? encrypt(phone_number) : null
         };
 
         return {
           sql: `
-            INSERT INTO vendor_credentials (vendor, username, password, id_number, card6_digits, nickname, bank_account_number)
-            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            INSERT INTO vendor_credentials (vendor, username, password, id_number, card6_digits, nickname, bank_account_number, phone_number)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
             RETURNING *
           `,
           params: [
@@ -55,7 +56,8 @@ const handler = createApiHandler({
             encryptedData.id_number,
             encryptedData.card6_digits,
             encryptedData.nickname,
-            encryptedData.bank_account_number
+            encryptedData.bank_account_number,
+            encryptedData.phone_number
           ]
         };
       }
@@ -69,12 +71,13 @@ const handler = createApiHandler({
         id: row.id,
         vendor: row.vendor,
         username: row.username ? safeDecrypt(row.username) : null,
-        // SECURITY: Never return passwords to the client
-        // password field is omitted for security
+        // SECURITY: Never return password or otp_long_term_token to the client
         id_number: row.id_number ? safeDecrypt(row.id_number) : null,
         card6_digits: row.card6_digits ? safeDecrypt(row.card6_digits) : null,
         nickname: row.nickname,
         bank_account_number: row.bank_account_number,
+        phone_number: row.phone_number ? safeDecrypt(row.phone_number) : null,
+        has_otp_long_term_token: !!row.otp_long_term_token,
         is_active: row.is_active !== false, // Default to true if null
         created_at: row.created_at,
         last_synced_at: row.last_synced_at

--- a/app/pages/api/scrapers/run-stream.js
+++ b/app/pages/api/scrapers/run-stream.js
@@ -20,7 +20,8 @@ import {
   processScrapedAccounts,
   checkScraperConcurrency,
 } from '../utils/scraperUtils';
-import { VaultLockedError } from '../utils/encryption';
+import { VaultLockedError, decrypt, encrypt } from '../utils/encryption';
+import { classifyScrapeError, ScrapeErrorTypes } from '../utils/scraperErrors';
 
 const CompanyTypes = {
   hapoalim: 'hapoalim',
@@ -33,6 +34,7 @@ const CompanyTypes = {
   massad: 'massad',
   yahav: 'yahav',
   beinleumi: 'beinleumi',
+  onezero: 'onezero',
   isracard: 'isracard',
   amex: 'amex',
   max: 'max',
@@ -102,8 +104,32 @@ async function handler(req, res) {
 
     const isBank = BANK_VENDORS.includes(options.companyId);
 
+    // OneZero: load the long-term OTP token from the DB (encrypted at rest, never travels in HTTP).
+    // If present, we'll skip the SMS round-trip; if absent, the scraper invokes our otpCodeRetriever.
+    let onezeroEnrichedCredentials = credentials;
+    if (options.companyId === 'onezero' && credentialId) {
+      try {
+        const tokenRow = await client.query(
+          'SELECT otp_long_term_token FROM vendor_credentials WHERE id = $1',
+          [credentialId]
+        );
+        const ciphertext = tokenRow.rows[0]?.otp_long_term_token;
+        if (ciphertext) {
+          onezeroEnrichedCredentials = {
+            ...credentials,
+            otpLongTermToken: decrypt(ciphertext)
+          };
+          logger.info({ credentialId }, '[Scrape Stream] OneZero: using stored long-term OTP token');
+        } else {
+          logger.info({ credentialId }, '[Scrape Stream] OneZero: no stored token, will request SMS OTP');
+        }
+      } catch (err) {
+        logger.warn({ error: err.message }, '[Scrape Stream] OneZero: failed to load stored token, falling back to SMS OTP');
+      }
+    }
+
     // Prepare and validate credentials
-    const scraperCredentials = prepareCredentials(options.companyId, credentials);
+    const scraperCredentials = prepareCredentials(options.companyId, onezeroEnrichedCredentials);
 
     try {
       validateCredentials(scraperCredentials, options.companyId);
@@ -312,24 +338,45 @@ async function handler(req, res) {
 
         result = await runScraper(client, scraperOptions, scraperCredentials, progressHandler, () => false);
 
+        // OneZero: if the scraper minted a fresh long-term token (first login or after expiry),
+        // persist it encrypted so subsequent syncs skip the SMS step.
+        if (options.companyId === 'onezero' && result?.persistentOtpToken && credentialId) {
+          try {
+            await client.query(
+              'UPDATE vendor_credentials SET otp_long_term_token = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2',
+              [encrypt(result.persistentOtpToken), credentialId]
+            );
+            logger.info({ credentialId }, '[Scrape Stream] OneZero: persisted long-term OTP token');
+          } catch (err) {
+            logger.warn({ error: err.message, credentialId }, '[Scrape Stream] OneZero: failed to persist long-term OTP token');
+          }
+        }
+
         if (!result.success) {
-          // Don't retry if OTP was involved - the browser session is specific to the OTP attempt
+          // OTP-specific short-circuit: browser session is bound to this attempt.
           if (result.otpPending) {
             logger.info('[Scrape Stream] OTP flow was triggered but failed - not retrying');
+            const classified = classifyScrapeError({ libResult: result, capturedResponse: result.capturedResponse });
+            const otpType = classified.type === ScrapeErrorTypes.UNKNOWN ? ScrapeErrorTypes.OTP_FAILED : classified.type;
             if (auditId) {
               await updateScrapeAudit(client, auditId, 'failed', result.errorMessage || 'OTP verification failed');
             }
             if (!res.finished) {
               sendSSE(res, 'error', {
-                message: result.errorMessage || 'OTP verification failed',
-                hint: 'Please try again and enter the OTP code when prompted.',
-                attemptsMade: attempt + 1
+                type: otpType,
+                message: classified.userMessage,
+                originalMessage: result.errorMessage || classified.originalMessage,
+                retryable: false,
+                attemptsMade: attempt + 1,
               });
               res.end();
             }
             return;
           }
-          throw new Error(result.errorMessage || 'Scraper failed');
+          const failure = new Error(result.errorMessage || 'Scraper failed');
+          failure._libResult = result;
+          failure.capturedResponse = result.capturedResponse;
+          throw failure;
         }
 
         // Success - break out of retry loop
@@ -348,28 +395,50 @@ async function handler(req, res) {
 
       } catch (scrapeError) {
         lastError = scrapeError.message;
+        const classified = classifyScrapeError({
+          thrownError: scrapeError,
+          libResult: scrapeError._libResult,
+          capturedResponse: scrapeError.capturedResponse,
+        });
         logger.error({
           attempt,
           maxRetries,
-          error: scrapeError.message
+          error: scrapeError.message,
+          classifiedType: classified.type,
+          retryable: classified.retryable,
         }, '[Scrape Stream] Scrape attempt failed');
 
-        // If this was the last attempt, give up
-        if (attempt >= maxRetries) {
-          logger.error({
-            totalAttempts: attempt + 1,
-            maxRetries
-          }, '[Scrape Stream] All retry attempts exhausted');
+        const isFinalAttempt = attempt >= maxRetries;
+        const giveUp = isFinalAttempt || !classified.retryable;
+
+        if (giveUp) {
+          if (!classified.retryable) {
+            logger.info({ classifiedType: classified.type }, '[Scrape Stream] Not retrying — error classified as non-retryable');
+          } else {
+            logger.error({
+              totalAttempts: attempt + 1,
+              maxRetries,
+            }, '[Scrape Stream] All retry attempts exhausted');
+          }
 
           if (auditId) {
-            await updateScrapeAudit(client, auditId, 'failed', `Failed after ${attempt + 1} attempts: ${scrapeError.message}`, null, attempt);
+            await updateScrapeAudit(
+              client,
+              auditId,
+              'failed',
+              `[${classified.type}] ${classified.originalMessage || scrapeError.message}`,
+              null,
+              attempt,
+            );
           }
 
           if (!res.finished) {
             sendSSE(res, 'error', {
-              message: `Scrape Failed: ${scrapeError.message}`,
-              hint: `Tried ${attempt + 1} time(s). Please try again later or check your credentials.`,
-              attemptsMade: attempt + 1
+              type: classified.type,
+              message: classified.userMessage,
+              originalMessage: classified.originalMessage || scrapeError.message,
+              retryable: classified.retryable,
+              attemptsMade: attempt + 1,
             });
             res.end();
           }

--- a/app/pages/api/utils/scraperErrors.js
+++ b/app/pages/api/utils/scraperErrors.js
@@ -1,0 +1,142 @@
+import logger from '../../../utils/logger.js';
+
+export const ScrapeErrorTypes = {
+  INVALID_CREDENTIALS: 'INVALID_CREDENTIALS',
+  ACCOUNT_BLOCKED: 'ACCOUNT_BLOCKED',
+  CHANGE_PASSWORD_REQUIRED: 'CHANGE_PASSWORD_REQUIRED',
+  OTP_REQUIRED: 'OTP_REQUIRED',
+  OTP_FAILED: 'OTP_FAILED',
+  NETWORK: 'NETWORK',
+  TIMEOUT: 'TIMEOUT',
+  PROVIDER_ERROR: 'PROVIDER_ERROR',
+  UNKNOWN: 'UNKNOWN',
+};
+
+const USER_MESSAGES = {
+  INVALID_CREDENTIALS: 'Login failed. Please verify the credentials for this account.',
+  ACCOUNT_BLOCKED: 'This account appears to be locked. Please log in via the provider’s app or website to unlock it.',
+  CHANGE_PASSWORD_REQUIRED: 'The provider is asking you to change your password before continuing.',
+  OTP_REQUIRED: 'Two-factor authentication is required to continue.',
+  OTP_FAILED: 'Two-factor verification failed or timed out.',
+  NETWORK: 'Network error while contacting the provider. Please check your connection.',
+  TIMEOUT: 'The provider took too long to respond. Please try again later.',
+  PROVIDER_ERROR: 'The provider returned an unexpected response. Please try again later.',
+  UNKNOWN: 'Sync failed due to an unexpected error.',
+};
+
+const RETRYABLE = {
+  INVALID_CREDENTIALS: false,
+  ACCOUNT_BLOCKED: false,
+  CHANGE_PASSWORD_REQUIRED: false,
+  OTP_REQUIRED: false,
+  OTP_FAILED: false,
+  NETWORK: true,
+  TIMEOUT: true,
+  PROVIDER_ERROR: false,
+  UNKNOWN: true,
+};
+
+const LIB_ERROR_TYPE_MAP = {
+  invalidPassword: ScrapeErrorTypes.INVALID_CREDENTIALS,
+  changePassword: ScrapeErrorTypes.CHANGE_PASSWORD_REQUIRED,
+  accountBlocked: ScrapeErrorTypes.ACCOUNT_BLOCKED,
+  timeout: ScrapeErrorTypes.TIMEOUT,
+  twoFactorRetrieverMissing: ScrapeErrorTypes.OTP_REQUIRED,
+  generic: ScrapeErrorTypes.UNKNOWN,
+};
+
+function classifyByMessage(rawMessage) {
+  const m = (rawMessage || '').toLowerCase();
+  if (!m) return null;
+  if (m.includes('econnrefused') || m.includes('enotfound') || m.includes('socket hang up') || m.includes('network error')) return ScrapeErrorTypes.NETWORK;
+  if (m.includes('timeout') || m.includes('timed out')) return ScrapeErrorTypes.TIMEOUT;
+  if (m.includes('change password') || m.includes('password expired') || m.includes('must change password')) return ScrapeErrorTypes.CHANGE_PASSWORD_REQUIRED;
+  if (m.includes('account blocked') || m.includes('account locked') || m.includes('account is locked')) return ScrapeErrorTypes.ACCOUNT_BLOCKED;
+  if (m.includes('invalid password') || m.includes('login failed') || m.includes('errorloginfailed') || m.includes('invalid credentials') || m.includes('unauthorized')) return ScrapeErrorTypes.INVALID_CREDENTIALS;
+  if (m.includes('otp') && (m.includes('failed') || m.includes('expired') || m.includes('invalid'))) return ScrapeErrorTypes.OTP_FAILED;
+  if (m.includes('cannot read properties of undefined') || m.includes('cannot read property')) return ScrapeErrorTypes.PROVIDER_ERROR;
+  return null;
+}
+
+function classifyByCapturedResponse(captured) {
+  if (!captured) return null;
+  const { status, body } = captured;
+  const lower = (body || '').toLowerCase();
+  if (lower.includes('errorloginfailed') || lower.includes('invalid_grant') || lower.includes('invalid credentials') || lower.includes('"invalidpassword"')) {
+    return ScrapeErrorTypes.INVALID_CREDENTIALS;
+  }
+  if (lower.includes('account_blocked') || lower.includes('account is locked') || lower.includes('accountblocked')) return ScrapeErrorTypes.ACCOUNT_BLOCKED;
+  if (lower.includes('change_password') || lower.includes('changepassword')) return ScrapeErrorTypes.CHANGE_PASSWORD_REQUIRED;
+  if (status === 401 || status === 403) return ScrapeErrorTypes.INVALID_CREDENTIALS;
+  if (status === 408 || status === 504) return ScrapeErrorTypes.TIMEOUT;
+  if (status >= 500) return ScrapeErrorTypes.PROVIDER_ERROR;
+  if (status >= 400) return ScrapeErrorTypes.PROVIDER_ERROR;
+  return null;
+}
+
+function buildResult(type, originalMessage) {
+  return {
+    type,
+    userMessage: USER_MESSAGES[type] || USER_MESSAGES.UNKNOWN,
+    retryable: RETRYABLE[type] ?? true,
+    originalMessage: originalMessage || null,
+  };
+}
+
+export function classifyScrapeError({ thrownError, libResult, capturedResponse } = {}) {
+  // 1. Most explicit: structured library errorType.
+  if (libResult && libResult.success === false && libResult.errorType && LIB_ERROR_TYPE_MAP[libResult.errorType]) {
+    return buildResult(LIB_ERROR_TYPE_MAP[libResult.errorType], libResult.errorMessage);
+  }
+  // 2. Wire-level response from the provider — higher signal than parsing message strings,
+  //    especially when the library swallowed the response (e.g. destructure crashes).
+  const fromCaptured = classifyByCapturedResponse(capturedResponse);
+  if (fromCaptured) {
+    const original = thrownError?.message || libResult?.errorMessage || (capturedResponse ? `HTTP ${capturedResponse.status}` : null);
+    return buildResult(fromCaptured, original);
+  }
+  // 3. Message-based heuristics (lib result first, then thrown error).
+  if (libResult && libResult.success === false) {
+    const fromMessage = classifyByMessage(libResult.errorMessage);
+    if (fromMessage) return buildResult(fromMessage, libResult.errorMessage);
+  }
+  if (thrownError) {
+    const fromMessage = classifyByMessage(thrownError.message);
+    if (fromMessage) return buildResult(fromMessage, thrownError.message);
+  }
+  return buildResult(ScrapeErrorTypes.UNKNOWN, thrownError?.message || libResult?.errorMessage);
+}
+
+export function installScrapeFetchInterceptor() {
+  const context = { lastFailedResponse: null };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    const response = await originalFetch(url, init);
+    if (!response.ok) {
+      try {
+        const cloned = response.clone();
+        const bodyText = await cloned.text();
+        const urlStr = typeof url === 'string' ? url : url?.url || '';
+        context.lastFailedResponse = {
+          url: urlStr,
+          status: response.status,
+          body: bodyText.slice(0, 4000),
+        };
+        logger.info({
+          url: urlStr,
+          status: response.status,
+          bodyPreview: bodyText.slice(0, 300),
+        }, '[Scraper] Provider returned non-2xx');
+      } catch {
+        // ignore body read errors
+      }
+    }
+    return response;
+  };
+  const restore = () => {
+    if (globalThis.fetch !== originalFetch) {
+      globalThis.fetch = originalFetch;
+    }
+  };
+  return { context, restore };
+}

--- a/app/pages/api/utils/scraperUtils.js
+++ b/app/pages/api/utils/scraperUtils.js
@@ -25,7 +25,8 @@ import {
 import { generateTransactionIdentifier } from './transactionUtils.js';
 import { createScraper } from 'israeli-bank-scrapers';
 import { handleHapoalimOtp, isOtpPage } from '../../../scrapers/hapoalimOtp.js';
-import { clearPendingOtp } from '../scrapers/otp.js';
+import { clearPendingOtp, waitForOtp } from '../scrapers/otp.js';
+import { installScrapeFetchInterceptor } from './scraperErrors.js';
 import logger from '../../../utils/logger.js';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
@@ -236,6 +237,9 @@ export function prepareCredentials(vendor, rawCredentials) {
     card6Digits,
     nickname,
     userCode,
+    email,
+    phoneNumber,
+    otpLongTermToken,
     ...rest
   } = rawCredentials;
 
@@ -247,6 +251,18 @@ export function prepareCredentials(vendor, rawCredentials) {
     const hapoalimUserCode = userCode || username || id || rawCredentials.id_number || '';
     credentials.userCode = String(hapoalimUserCode);
     credentials.password = String(password || '');
+  } else if (vendor === 'onezero') {
+    // OneZero uses email + password and one of two 2FA modes:
+    //   1. otpLongTermToken (re-login without SMS)
+    //   2. phoneNumber + otpCodeRetriever callback (first-time / after token expiry)
+    // The otpCodeRetriever is wired in runScraper(), not here, since it depends on the live progress emitter.
+    credentials.email = String(email || username || '');
+    credentials.password = String(password || '');
+    if (otpLongTermToken) {
+      credentials.otpLongTermToken = String(otpLongTermToken);
+    } else if (phoneNumber) {
+      credentials.phoneNumber = String(phoneNumber);
+    }
   } else if (STANDARD_BANK_VENDORS.includes(vendor) || BEINLEUMI_GROUP_VENDORS.includes(vendor) || vendor === 'igud' || vendor === 'massad' || vendor === 'discount') {
     // Standard bank login (username + password, sometimes num)
     credentials.username = username;
@@ -274,6 +290,13 @@ export function validateCredentials(credentials, vendor) {
   if (vendor === 'hapoalim') {
     if (!credentials.userCode || !credentials.password) {
       throw new Error(`Invalid credentials for ${vendor}: userCode and password are required.`);
+    }
+  } else if (vendor === 'onezero') {
+    if (!credentials.email || !credentials.password) {
+      throw new Error(`Invalid credentials for ${vendor}: email and password are required.`);
+    }
+    if (!credentials.otpLongTermToken && !credentials.phoneNumber) {
+      throw new Error(`Invalid credentials for ${vendor}: either otpLongTermToken or phoneNumber is required.`);
     }
   } else if (vendor === 'isracard' || vendor === 'amex') {
     if (!credentials.id || !credentials.card6Digits || !credentials.password) {
@@ -779,11 +802,18 @@ export async function runScraper(client, scraperOptions, credentials, onProgress
   // OTP flow can take up to MAX_OTP_ATTEMPTS (3) × OTP_USER_TIMEOUT_MS (180s) of user wait
   // plus per-attempt processing — give it generous headroom.
   const isHapoalim = scraperOptions.companyId === 'hapoalim';
+  // OneZero only triggers OTP on first login or after token expiry, but we still budget for
+  // a single 3-minute SMS wait. The scrape's global race promise enforces the real ceiling.
+  const isOneZero = scraperOptions.companyId === 'onezero';
+  const oneZeroNeedsOtp = isOneZero && !credentials?.otpLongTermToken;
   let effectiveTimeout = scraperOptions.timeout || DEFAULT_SCRAPER_TIMEOUT;
   if (isHapoalim) {
     const otpExtraTimeout = 600000; // 10 min headroom for the OTP flow (3 attempts × 3 min + slack)
     effectiveTimeout += otpExtraTimeout;
     logger.info({ originalTimeout: scraperOptions.timeout, effectiveTimeout }, '[Scraper] Extended timeout for Hapoalim OTP');
+  } else if (oneZeroNeedsOtp) {
+    effectiveTimeout += 240000; // 4 min headroom for one SMS round-trip + slack
+    logger.info({ originalTimeout: scraperOptions.timeout, effectiveTimeout }, '[Scraper] Extended timeout for OneZero OTP');
   }
 
   let options = {
@@ -837,7 +867,10 @@ export async function runScraper(client, scraperOptions, credentials, onProgress
     // createScraper code: return new Scraper(options);
     scraper = new CustomVisaCalScraper(options);
   } else {
-    scraper = createScraper(options);
+    const libraryOptions = options.companyId === 'onezero'
+      ? { ...options, companyId: 'oneZero' }
+      : options;
+    scraper = createScraper(libraryOptions);
   }
 
   if (scraper && typeof scraper.onProgress === 'function') {
@@ -867,6 +900,56 @@ export async function runScraper(client, scraperOptions, credentials, onProgress
       return;
     };
   }
+
+  // OneZero: native 2FA wiring.
+  //   - When no long-term token exists, inject otpCodeRetriever that pipes through the
+  //     shared waitForOtp() promise store (same channel the existing UI submits to).
+  //   - Wrap getLongTermTwoFactorToken to capture the new long-term token and emit
+  //     otpSuccess/otpFailed progress events for the UI.
+  let capturedOneZeroToken = null;
+  let oneZeroOtpFailed = false;
+  if (oneZeroNeedsOtp) {
+    const ONEZERO_OTP_USER_TIMEOUT_MS = 180_000;
+    credentials = {
+      ...credentials,
+      otpCodeRetriever: async () => {
+        logger.info('[Scraper] OneZero OTP requested by scraper, awaiting user input');
+        if (onProgress) onProgress(scraperOptions.companyId, { type: 'otpRequired' });
+        try {
+          const code = await waitForOtp('onezero', ONEZERO_OTP_USER_TIMEOUT_MS);
+          if (onProgress) onProgress(scraperOptions.companyId, { type: 'otpSubmitting' });
+          return code;
+        } catch (err) {
+          logger.warn({ error: err.message }, '[Scraper] OneZero OTP wait failed/timed out');
+          if (onProgress) onProgress(scraperOptions.companyId, { type: 'otpFailed' });
+          oneZeroOtpFailed = true;
+          throw err;
+        }
+      }
+    };
+
+    if (typeof scraper.getLongTermTwoFactorToken === 'function') {
+      const originalGet = scraper.getLongTermTwoFactorToken.bind(scraper);
+      scraper.getLongTermTwoFactorToken = async (otpCode) => {
+        const tokenResult = await originalGet(otpCode);
+        if (tokenResult?.success && tokenResult.longTermTwoFactorAuthToken) {
+          capturedOneZeroToken = tokenResult.longTermTwoFactorAuthToken;
+          logger.info('[Scraper] OneZero captured long-term OTP token for persistence');
+          if (onProgress) onProgress(scraperOptions.companyId, { type: 'otpSuccess' });
+        } else {
+          logger.warn({ result: tokenResult }, '[Scraper] OneZero token exchange failed');
+          if (onProgress) onProgress(scraperOptions.companyId, { type: 'otpFailed' });
+          oneZeroOtpFailed = true;
+        }
+        return tokenResult;
+      };
+    }
+  }
+
+  // Capture provider non-2xx responses so the caller can classify failures
+  // even when the upstream library swallows the response (e.g. via destructuring
+  // a missing field on an error body).
+  const fetchInterceptor = installScrapeFetchInterceptor();
 
   logger.info('[Scraper] Starting scrape execution');
 
@@ -1169,6 +1252,17 @@ export async function runScraper(client, scraperOptions, credentials, onProgress
     }
 
     clearActiveSession();
+    if (capturedOneZeroToken) {
+      result.persistentOtpToken = capturedOneZeroToken;
+    }
+    if (oneZeroOtpFailed && !result.success) {
+      // Mark so the run-stream retry loop doesn't re-trigger an SMS for the user.
+      result.otpPending = true;
+    }
+    if (fetchInterceptor.context.lastFailedResponse && !result.success) {
+      result.capturedResponse = fetchInterceptor.context.lastFailedResponse;
+    }
+    fetchInterceptor.restore();
     return result;
   } catch (err) {
     clearTimeout(timeoutId);
@@ -1180,9 +1274,14 @@ export async function runScraper(client, scraperOptions, credentials, onProgress
       vendor: scraperOptions.companyId
     }, '[Scraper] Fatal error during scrape');
 
+    if (fetchInterceptor.context.lastFailedResponse) {
+      err.capturedResponse = fetchInterceptor.context.lastFailedResponse;
+    }
+
     // Ensure we close if error happened during smart scrape or OTP
     if (originalTerminate) await originalTerminate();
     clearActiveSession();
+    fetchInterceptor.restore();
 
     throw err;
   }

--- a/app/tests/scraperErrors.test.ts
+++ b/app/tests/scraperErrors.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+
+vi.mock('../utils/logger.js', () => ({
+    default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() }
+}));
+
+import { vi } from 'vitest';
+import { classifyScrapeError, ScrapeErrorTypes } from '../pages/api/utils/scraperErrors.js';
+
+describe('classifyScrapeError', () => {
+    it('maps library errorType invalidPassword to INVALID_CREDENTIALS', () => {
+        const result = classifyScrapeError({
+            libResult: { success: false, errorType: 'invalidPassword', errorMessage: 'wrong password' }
+        });
+        expect(result.type).toBe(ScrapeErrorTypes.INVALID_CREDENTIALS);
+        expect(result.retryable).toBe(false);
+    });
+
+    it('maps library errorType timeout to TIMEOUT (retryable)', () => {
+        const result = classifyScrapeError({
+            libResult: { success: false, errorType: 'timeout', errorMessage: 'timed out' }
+        });
+        expect(result.type).toBe(ScrapeErrorTypes.TIMEOUT);
+        expect(result.retryable).toBe(true);
+    });
+
+    it('classifies OneZero ErrorLoginFailed body as INVALID_CREDENTIALS', () => {
+        // Mirrors production: lib swallowed the response, threw a destructure error,
+        // and run-stream wrapped the failure with both the libResult and the captured response.
+        const result = classifyScrapeError({
+            thrownError: new Error("Cannot read properties of undefined (reading 'idToken')"),
+            libResult: {
+                success: false,
+                errorMessage: "Cannot read properties of undefined (reading 'idToken')"
+            },
+            capturedResponse: {
+                url: 'https://identity.tfd-bank.com/v1//getIdToken',
+                status: 500,
+                body: '{"errorResponse":{"type":"ErrorLoginFailed"}}'
+            }
+        });
+        expect(result.type).toBe(ScrapeErrorTypes.INVALID_CREDENTIALS);
+        expect(result.retryable).toBe(false);
+    });
+
+    it('classifies HTTP 401 as INVALID_CREDENTIALS', () => {
+        const result = classifyScrapeError({
+            capturedResponse: { url: 'https://x', status: 401, body: '' }
+        });
+        expect(result.type).toBe(ScrapeErrorTypes.INVALID_CREDENTIALS);
+    });
+
+    it('classifies HTTP 5xx with no auth signal as PROVIDER_ERROR', () => {
+        const result = classifyScrapeError({
+            capturedResponse: { url: 'https://x', status: 503, body: 'maintenance' }
+        });
+        expect(result.type).toBe(ScrapeErrorTypes.PROVIDER_ERROR);
+        expect(result.retryable).toBe(false);
+    });
+
+    it('classifies network errors as NETWORK (retryable)', () => {
+        const result = classifyScrapeError({
+            thrownError: new Error('connect ECONNREFUSED 1.2.3.4:443')
+        });
+        expect(result.type).toBe(ScrapeErrorTypes.NETWORK);
+        expect(result.retryable).toBe(true);
+    });
+
+    it('falls back to UNKNOWN for unrecognised errors', () => {
+        const result = classifyScrapeError({
+            thrownError: new Error('something weird happened')
+        });
+        expect(result.type).toBe(ScrapeErrorTypes.UNKNOWN);
+    });
+
+    it('classifies a destructure crash with no captured response as PROVIDER_ERROR', () => {
+        const result = classifyScrapeError({
+            thrownError: new Error("Cannot read properties of undefined (reading 'foo')")
+        });
+        expect(result.type).toBe(ScrapeErrorTypes.PROVIDER_ERROR);
+    });
+});

--- a/app/tests/scraperUtils.test.ts
+++ b/app/tests/scraperUtils.test.ts
@@ -263,6 +263,40 @@ describe('ScraperUtils', () => {
                 });
             });
         });
+
+        describe('OneZero', () => {
+            it('should map email + password + phoneNumber for first-time login', () => {
+                const result = prepareCredentials('onezero', {
+                    email: 'user@example.com',
+                    password: 'secret',
+                    phoneNumber: '+972501234567'
+                });
+                expect(result.email).toBe('user@example.com');
+                expect(result.password).toBe('secret');
+                expect(result.phoneNumber).toBe('+972501234567');
+                expect(result.otpLongTermToken).toBeUndefined();
+            });
+
+            it('should fall back to username column for email when email is absent', () => {
+                const result = prepareCredentials('onezero', {
+                    username: 'user@example.com',
+                    password: 'secret',
+                    phoneNumber: '+972501234567'
+                });
+                expect(result.email).toBe('user@example.com');
+            });
+
+            it('should pass otpLongTermToken when present and skip phoneNumber', () => {
+                const result = prepareCredentials('onezero', {
+                    email: 'user@example.com',
+                    password: 'secret',
+                    phoneNumber: '+972501234567',
+                    otpLongTermToken: 'long.lived.jwt'
+                });
+                expect(result.otpLongTermToken).toBe('long.lived.jwt');
+                expect(result.phoneNumber).toBeUndefined();
+            });
+        });
     });
 
     describe('validateCredentials', () => {
@@ -301,6 +335,33 @@ describe('ScraperUtils', () => {
                     expect(() => validateCredentials({ id: '123', card6Digits: '123456', password: 'pass' }, vendor))
                         .not.toThrow();
                 });
+            });
+        });
+
+        describe('OneZero', () => {
+            it('should throw when email is missing', () => {
+                expect(() => validateCredentials({ password: 'pass', phoneNumber: '+972501234567' }, 'onezero'))
+                    .toThrow(/email and password are required/);
+            });
+
+            it('should throw when password is missing', () => {
+                expect(() => validateCredentials({ email: 'a@b.com', phoneNumber: '+972501234567' }, 'onezero'))
+                    .toThrow(/email and password are required/);
+            });
+
+            it('should throw when neither phoneNumber nor otpLongTermToken is provided', () => {
+                expect(() => validateCredentials({ email: 'a@b.com', password: 'pass' }, 'onezero'))
+                    .toThrow(/otpLongTermToken or phoneNumber is required/);
+            });
+
+            it('should not throw with email + password + phoneNumber', () => {
+                expect(() => validateCredentials({ email: 'a@b.com', password: 'pass', phoneNumber: '+972501234567' }, 'onezero'))
+                    .not.toThrow();
+            });
+
+            it('should not throw with email + password + otpLongTermToken', () => {
+                expect(() => validateCredentials({ email: 'a@b.com', password: 'pass', otpLongTermToken: 'tok' }, 'onezero'))
+                    .not.toThrow();
             });
         });
 


### PR DESCRIPTION
## Summary

- **OneZero (Bank ONE ZERO) support**: native 2FA via SMS + long-term token persistence. Library company-id mismatch (`onezero` vs `oneZero`) fixed at the `createScraper` boundary only — internal key stays lowercase to match DB rows.
- **Provider-agnostic error classifier**: wire-level interceptor + classifier turns library destructure crashes / opaque failures into a small enum (`INVALID_CREDENTIALS`, `ACCOUNT_BLOCKED`, `OTP_REQUIRED/FAILED`, `NETWORK`, `TIMEOUT`, `PROVIDER_ERROR`, `UNKNOWN`) with `retryable` flag. Retry loop short-circuits on non-retryable classifications.
- **UI**: friendly messages instead of raw stack traces; `KnownSyncFailure` lets the outer catch log classified failures at `warn` level instead of dumping the raw Error to the browser console.

## How it hangs together

Originally the OneZero scrape was failing with `Cannot read properties of undefined (reading 'idToken')` — an unconditional destructure inside `israeli-bank-scrapers/lib/scrapers/one-zero.js:117-121` after the provider returned HTTP 500 with `{"errorResponse":{"type":"ErrorLoginFailed"}}`. The library swallowed the response, the UI showed the destructure crash as a red stack trace, and the retry loop hammered the server 3 more times.

The fix is two-layer:

1. **Generic fetch interceptor** (`installScrapeFetchInterceptor` in `pages/api/utils/scraperErrors.js`) records the most recent non-2xx provider response during a scrape. Stays installed for *all* providers — diagnostics for free if any other library crashes the same way.
2. **Classifier** prefers the wire response over message-string heuristics. For OneZero the captured `ErrorLoginFailed` body now correctly classifies as `INVALID_CREDENTIALS` (not retryable), so the user sees "Login failed. Please verify the credentials for this account." instead of the raw destructure error.

OneZero 2FA itself: `migrations/011_onezero_2fa.sql` adds `phone_number` and `otp_long_term_token` (both encrypted ciphertext, TEXT columns since long-term tokens are JWT-shaped). First sync triggers SMS via the existing `waitForOtp()` channel; subsequent syncs reuse the stored token. Password changes clear the token. The credentials API exposes only `has_otp_long_term_token` (boolean) — the token itself never crosses the network.

## Files of note

- `pages/api/utils/scraperErrors.js` (new) — classifier + interceptor.
- `pages/api/utils/scraperUtils.js` — OneZero credential prep, OTP wiring, library company-id translation, interceptor install.
- `pages/api/scrapers/run-stream.js` — token load/persist, structured SSE error events, retry short-circuit.
- `components/SyncStatusModal.tsx` — `KnownSyncFailure` for quiet logging of expected failures.
- `migrations/011_onezero_2fa.sql` — idempotent column adds.

## Test plan

- [x] `npm run test` — 664/664 pass (8 new classifier tests + 8 new OneZero credential tests).
- [x] `tsc --noEmit` clean for changed files; pre-existing TS issues in unrelated test files not touched.
- [x] `eslint` clean for new files.
- [x] Live test against the OneZero provider:
  - First-time SMS OTP flow → token captured & persisted.
  - Subsequent syncs skip SMS, use stored token.
  - Bad credentials → SSE error type `INVALID_CREDENTIALS`, no retry, friendly message in UI, no red stack trace in console.
- [ ] Verify migration runs cleanly on a fresh DB and on an existing DB (no-op via `IF NOT EXISTS`).
- [ ] Verify password change clears stored OTP token (PUT `/api/credentials/[id]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)