### PR TITLE
fix(vault): anchor VaultStore singleton on globalThis

### DIFF
--- a/app/pages/api/utils/VaultStore.js
+++ b/app/pages/api/utils/VaultStore.js
@@ -1,6 +1,11 @@
 /**
  * VaultStore is a simple in-memory singleton to store the decrypted master key.
  * This key is lost when the application process restarts.
+ *
+ * Anchored on globalThis under a Symbol.for key so that, even when Next.js bundles
+ * this module into multiple server bundles (instrumentation vs API routes in
+ * standalone output), all copies resolve to the same instance — the API route
+ * that unlocks the vault and the cron callback that reads it must share state.
  */
 class VaultStore {
     constructor() {
@@ -39,6 +44,9 @@ class VaultStore {
     }
 }
 
-// Singleton instance
-const instance = new VaultStore();
+const GLOBAL_KEY = Symbol.for('nudlers.VaultStore');
+if (!globalThis[GLOBAL_KEY]) {
+    globalThis[GLOBAL_KEY] = new VaultStore();
+}
+const instance = globalThis[GLOBAL_KEY];
 export default instance;


### PR DESCRIPTION
## Summary
- Background-sync cron failed with `VaultLockedError` after a successful unlock because the instrumentation bundle and the API-route bundles each held a separate copy of `VaultStore.js`. Unlock wrote the master key into one singleton; the cron read from another (always `null`).
- Anchors the singleton on `globalThis[Symbol.for('nudlers.VaultStore')]` so every bundled copy of the module dereferences the same in-memory instance.

## Why this is needed even after PR #89
PR #89 fixed an extension-mismatch (`./encryption` vs `./encryption.js`) that gave background-sync its own encryption module copy. With Next.js `output: 'standalone'`, each server entry (instrumentation, each API route) is bundled separately, so `VaultStore.js` is still inlined per bundle. The diagnostic run reproduced the bug in pid 77577: unlock at 05:24 succeeded, the 05:30 sync cron in the same process threw `Vault is locked`.

## Test plan
- [x] `npm run test` — 665/665 pass
- [x] `tests/vault.test.ts`, `tests/vault-api.test.ts`, `tests/encryption.test.ts`, `tests/credentials_api.test.ts` all green
- [ ] Manual: unlock vault, wait for the next `0 * * * *` sync cron firing, confirm `[Background Sync] Account sync completed` instead of `Vault is locked`

## Risk
- Diff is 8 lines in one file. Default export shape unchanged; no call sites need to change.
- `Symbol.for` is process-scoped — does not broaden access compared to importing the module.
- Side benefit: vault state survives Next dev HMR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)