### PR TITLE
fix(whatsapp): verify connection before send and reconnect if dead

### DIFF
--- a/app/tests/whatsapp.test.ts
+++ b/app/tests/whatsapp.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { sendWhatsAppMessage } from '../utils/whatsapp.js';
-import { getOrCreateClient } from '../utils/whatsapp-client.js';
+import { ensureConnected } from '../utils/whatsapp-client.js';
 
 // Mock the modules
 vi.mock('../utils/whatsapp-client.js', () => ({
-    getOrCreateClient: vi.fn(),
+    ensureConnected: vi.fn(),
 }));
 
 vi.mock('../utils/logger.js', () => ({
@@ -23,10 +23,7 @@ describe('sendWhatsAppMessage', () => {
         mockClient = {
             sendMessage: vi.fn().mockResolvedValue({ id: { _serialized: 'msg123' } }),
         };
-        (getOrCreateClient as any).mockReturnValue(mockClient);
-
-        // Mock global status
-        (global as any).whatsappStatus = 'READY';
+        (ensureConnected as any).mockResolvedValue(mockClient);
     });
 
     it('should send a message to a single phone number', async () => {
@@ -74,13 +71,15 @@ describe('sendWhatsAppMessage', () => {
         expect(result.sent).toBe(2);
     });
 
-    it('should throw error if client is not ready', async () => {
-        (global as any).whatsappStatus = 'DISCONNECTED';
+    it('should throw error if client cannot be connected', async () => {
+        (ensureConnected as any).mockRejectedValueOnce(
+            new Error('WhatsApp client did not become ready within 60000ms')
+        );
 
         await expect(sendWhatsAppMessage({
             to: '972501234567',
             body: 'Hello',
-        })).rejects.toThrow(/WhatsApp client not ready/);
+        })).rejects.toThrow(/did not become ready/);
     });
 
     it('should continue if one recipient fails but others succeed', async () => {

--- a/app/utils/whatsapp-client.js
+++ b/app/utils/whatsapp-client.js
@@ -269,6 +269,62 @@ export async function restartClient() {
     return initializeClient();
 }
 
+const READY_TIMEOUT_MS = 60000;
+
+/**
+ * Wait until `ready` fires (or `auth_failure` / timeout). Used by ensureConnected()
+ * after a fresh init to confirm the client is actually usable, not just constructed.
+ */
+function waitForReady(client, timeoutMs) {
+    return new Promise((resolve, reject) => {
+        const cleanup = () => {
+            clearTimeout(timer);
+            client.off?.('ready', onReady);
+            client.off?.('auth_failure', onAuthFail);
+        };
+        const onReady = () => { cleanup(); resolve(); };
+        const onAuthFail = (msg) => {
+            cleanup();
+            reject(new Error(`WhatsApp authentication failure: ${msg}`));
+        };
+        const timer = setTimeout(() => {
+            cleanup();
+            reject(new Error(`WhatsApp client did not become ready within ${timeoutMs}ms`));
+        }, timeoutMs);
+        client.once('ready', onReady);
+        client.once('auth_failure', onAuthFail);
+    });
+}
+
+/**
+ * Verify the client is actually connected and ready to send.
+ * Probes client.getState() — this catches the "zombie READY" case where our
+ * cached event-based status is READY but the underlying Chromium has died.
+ * If unhealthy or missing, restarts and waits for `ready` before returning.
+ * Throws if reconnection fails (e.g. session expired and a fresh QR scan is needed).
+ */
+export async function ensureConnected({ timeoutMs = READY_TIMEOUT_MS } = {}) {
+    const existing = getClient();
+    if (existing) {
+        try {
+            const state = await existing.getState();
+            if (state === 'CONNECTED') {
+                return existing;
+            }
+            logger.warn({ state }, 'WhatsApp client not CONNECTED, will reconnect before sending');
+        } catch (err) {
+            logger.warn({ err: err.message }, 'WhatsApp client.getState() threw, will reconnect before sending');
+        }
+    } else {
+        logger.info('No WhatsApp client instance, will initialize before sending');
+    }
+
+    const fresh = await restartClient();
+    await waitForReady(fresh, timeoutMs);
+    logger.info('WhatsApp client reconnected and ready');
+    return fresh;
+}
+
 /**
  * Clear the persisted WhatsApp session from disk.
  * This removes the stored authentication data, requiring a fresh QR scan.

--- a/app/utils/whatsapp.js
+++ b/app/utils/whatsapp.js
@@ -1,5 +1,5 @@
 import logger from './logger.js';
-import { getOrCreateClient } from './whatsapp-client.js';
+import { ensureConnected } from './whatsapp-client.js';
 
 /**
  * Sends a WhatsApp message using the internal singleton client.
@@ -13,13 +13,10 @@ export async function sendWhatsAppMessage({ to, body }) {
     }
 
     try {
-        const client = getOrCreateClient();
-        const globalAny = global;
-        const status = globalAny.whatsappStatus;
-
-        if (status !== 'READY' && status !== 'AUTHENTICATED') {
-            throw new Error(`WhatsApp client not ready (Status: ${status}). Please scan QR code in settings.`);
-        }
+        // Verify the client is alive (probes getState) and reconnect if not.
+        // This is the safety net that keeps daily summaries flowing after the
+        // long-running session inevitably degrades.
+        const client = await ensureConnected();
 
         // Split by comma for multiple recipients
         const recipients = to.split(',').map(r => r.trim()).filter(Boolean);


### PR DESCRIPTION
## Summary
- WhatsApp would silently stop working after a few days because the only pre-send gate was a cached event-based status flag — Chromium would die or drift into a "zombie READY" state where the flag still said `READY` but `sendMessage` hung or failed.
- Adds `ensureConnected()` in `whatsapp-client.js`: probes `client.getState()` (single round-trip on the healthy path); if it throws or returns anything other than `CONNECTED`, restarts the client and waits for the `ready` event with a 60s timeout.
- `sendWhatsAppMessage` now awaits `ensureConnected()` instead of reading `globalAny.whatsappStatus`. Every caller — the daily summary cron, the manual test endpoint, anything we add later — gets the same safety net.

## Behavior
- **Healthy days:** ~negligible extra latency for the `getState()` probe.
- **Zombie / disconnected days:** cron blocks up to 60s while reconnecting, then sends — instead of dropping the daily summary.
- **Session truly expired (needs new QR):** fails fast with a clear timeout error logged to `scrape_events`, so the failure surfaces same-day instead of "a few days later."

## Test plan
- [x] `npx vitest run tests/whatsapp.test.ts tests/whatsapp-client.test.ts` — 26/26 passing
- [ ] Verify the daily WhatsApp summary still arrives on schedule for at least one full week
- [ ] Force a zombie state (kill the headless Chromium process out from under the client) and confirm the next send reconnects rather than throwing

🤖 Generated with [Claude Code](https://claude.com/claude-code)