### PR TITLE
feat(docs): aurora redesign — Hebrew-first marketing site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,567 +1,865 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="he" dir="rtl" data-lang="he">
 
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Nudlers - Personal Finance for Israeli Banks</title>
+    <title>Nudlers · הפיננסים האישיים שלך, אצלך בבית</title>
     <meta name="description"
-        content="Self-hosted personal finance app that aggregates transactions from Israeli banks and credit cards. Track expenses, set budgets, and get AI-powered insights.">
-    <link rel="stylesheet" href="style.css">
+        content="Nudlers מאחד את כל החשבונות והכרטיסים הישראליים שלך לדשבורד אחד. סורק, מקטלג, מתקצב — ופועל על השרת שלך, בלי שאף אחד אחר נוגע בנתונים.">
+    <meta property="og:title" content="Nudlers · הפיננסים האישיים שלך, אצלך בבית">
+    <meta property="og:description" content="כל החשבונות, כל הכרטיסים — מקום אחד. מקומי, מוצפן, פתוח.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://nudlers.com">
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
+
+    <script>
+        // Set language + direction before paint to prevent flicker.
+        (function () {
+            var saved = null;
+            try { saved = localStorage.getItem('nudlers-lang'); } catch (_) { }
+            var lang = (saved === 'en' || saved === 'he') ? saved : 'he';
+            document.documentElement.lang = lang;
+            document.documentElement.dir = lang === 'he' ? 'rtl' : 'ltr';
+            document.documentElement.dataset.lang = lang;
+        })();
+    </script>
+
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link
+        href="https://fonts.googleapis.com/css2?family=Heebo:wght@300;400;500;700;900&family=Assistant:wght@400;500;600&family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap"
+        rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
 </head>
 
 <body>
 
+    <!-- ────────────────────────────────────────────────────────────
+         Aurora background — three slowly drifting radial gradients
+         on a dark canvas. Pure CSS, no canvas, GPU-friendly.
+         ──────────────────────────────────────────────────────────── -->
+    <div class="aurora" aria-hidden="true">
+        <div class="aurora-blob blob-violet"></div>
+        <div class="aurora-blob blob-cyan"></div>
+        <div class="aurora-blob blob-magenta"></div>
+        <div class="aurora-grain"></div>
+    </div>
+
+    <!-- ────────────── NAV ────────────── -->
     <nav class="nav">
         <div class="nav-inner">
             <a href="#" class="nav-logo">
                 <img src="assets/icon.svg" alt="Nudlers" class="nav-logo-img">
                 <span>Nudlers</span>
             </a>
+
             <div class="nav-links">
-                <a href="#preview">Preview</a>
-                <a href="#features">Features</a>
-                <a href="#credits">Credits</a>
-                <a href="#installation">Install</a>
-                <a href="#faq">FAQ</a>
-                <a href="https://github.com/enudler/nudlers" class="nav-btn" target="_blank" rel="noopener">GitHub</a>
+                <a href="#preview"><span class="he">תצוגה</span><span class="en">Preview</span></a>
+                <a href="#features"><span class="he">יכולות</span><span class="en">Features</span></a>
+                <a href="#security"><span class="he">אבטחה</span><span class="en">Security</span></a>
+                <a href="#install"><span class="he">התקנה</span><span class="en">Install</span></a>
+                <a href="#faq"><span class="he">שאלות</span><span class="en">FAQ</span></a>
             </div>
-            <button class="nav-toggle" aria-label="Toggle menu">
-                <span></span><span></span><span></span>
-            </button>
+
+            <div class="nav-actions">
+                <button class="lang-toggle" aria-label="Toggle language" type="button">
+                    <span class="lang-toggle-track">
+                        <span class="lang-toggle-pill" aria-hidden="true"></span>
+                        <span class="lang-toggle-opt" data-lang-set="he">עב</span>
+                        <span class="lang-toggle-opt" data-lang-set="en">EN</span>
+                    </span>
+                </button>
+                <a href="https://github.com/enudler/nudlers" class="nav-btn" target="_blank" rel="noopener">
+                    <svg viewBox="0 0 24 24" fill="currentColor" width="16" height="16" aria-hidden="true">
+                        <path
+                            d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
+                    </svg>
+                    <span>GitHub</span>
+                </a>
+                <button class="nav-toggle" aria-label="Toggle menu" type="button">
+                    <span></span><span></span><span></span>
+                </button>
+            </div>
         </div>
     </nav>
 
+    <!-- ────────────── HERO ────────────── -->
     <header class="hero">
-        <div class="container">
-            <div class="hero-badge">Self-hosted &middot; Open Source &middot; Privacy First</div>
+        <div class="container hero-inner">
+            <div class="hero-badge">
+                <span class="hero-badge-dot"></span>
+                <span class="he">מקומי · קוד פתוח · מוצפן מקצה לקצה</span>
+                <span class="en">Self-hosted · Open Source · End-to-end encrypted</span>
+            </div>
 
-            <h1>Take control of your<br><span class="gradient-text">Israeli finances</span></h1>
+            <h1 class="hero-title">
+                <span class="he">
+                    הכסף שלך,
+                    <span class="hero-accent">אצלך בבית.</span>
+                </span>
+                <span class="en">
+                    Your money,
+                    <span class="hero-accent">at home with you.</span>
+                </span>
+            </h1>
+
             <p class="hero-sub">
-                Nudlers aggregates transactions from all your Israeli banks and credit cards into one dashboard.
-                Track expenses, categorize spending, set budgets, and get AI-powered insights &mdash; all running on
-                your own hardware.
+                <span class="he">
+                    Nudlers מאחד את כל החשבונות והכרטיסים הישראליים שלך לדשבורד אחד.
+                    סורק, מקטלג, מתקצב, שולח סיכומים בוואטסאפ — ופועל על השרת שלך, בלי שאף אחד אחר רואה את הנתונים.
+                </span>
+                <span class="en">
+                    Nudlers brings every Israeli bank and credit card you own into a single dashboard.
+                    It scrapes, categorises, budgets, and pings WhatsApp summaries — all running on your hardware,
+                    where nobody else gets to see your data.
+                </span>
             </p>
+
             <div class="hero-actions">
-                <a href="#installation" class="btn btn-primary">Get Started</a>
-                <a href="#features" class="btn btn-secondary">Learn More</a>
+                <a href="#install" class="btn btn-primary">
+                    <span class="he">התחלה ✦</span>
+                    <span class="en">Get started ✦</span>
+                </a>
+                <a href="#preview" class="btn btn-ghost">
+                    <span class="he">תצוגה חיה</span>
+                    <span class="en">See it live</span>
+                </a>
+            </div>
+
+            <div class="hero-stats">
+                <div class="hero-stat">
+                    <div class="hero-stat-num">10+</div>
+                    <div class="hero-stat-label"><span class="he">בנקים וחברות אשראי</span><span class="en">Banks &amp;
+                            cards</span></div>
+                </div>
+                <div class="hero-stat">
+                    <div class="hero-stat-num">0</div>
+                    <div class="hero-stat-label"><span class="he">שרתים חיצוניים</span><span class="en">External
+                            servers</span></div>
+                </div>
+                <div class="hero-stat">
+                    <div class="hero-stat-num">100%</div>
+                    <div class="hero-stat-label"><span class="he">הקוד פתוח</span><span class="en">Open source</span>
+                    </div>
+                </div>
             </div>
         </div>
     </header>
 
+    <!-- ────────────── PREVIEW CAROUSEL ────────────── -->
     <section id="preview" class="section">
         <div class="container">
-            <h2 class="section-title">See it in action</h2>
-            <p class="section-sub">A clean, modern interface for managing all your Israeli financial accounts.</p>
+            <div class="section-head">
+                <div class="section-eyebrow"><span class="he">תצוגה</span><span class="en">Preview</span></div>
+                <h2 class="section-title">
+                    <span class="he">איך זה נראה.</span>
+                    <span class="en">How it looks.</span>
+                </h2>
+                <p class="section-sub">
+                    <span class="he">דשבורד נקי, צבעים שקטים, ועברית מובנת מעצמה — מימין לשמאל.</span>
+                    <span class="en">A clean dashboard, calm colours, and proper RTL Hebrew baked in from day one.</span>
+                </p>
+            </div>
 
-            <div class="carousel">
-                <div class="carousel-viewport">
-                    <div class="carousel-track">
-                        <div class="carousel-slide active">
-                            <div class="carousel-img">
-                                <img src="assets/summary.png" alt="Monthly spending summary dashboard" loading="lazy">
+            <div class="carousel" tabindex="0">
+                <div class="carousel-frame">
+                    <div class="carousel-viewport">
+                        <div class="carousel-track">
+                            <div class="carousel-slide active">
+                                <img src="assets/summary.png" alt="Monthly summary dashboard" loading="lazy">
                             </div>
-                        </div>
-                        <div class="carousel-slide">
-                            <div class="carousel-img">
-                                <img src="assets/transactions.png" alt="Transactions view with search and filtering"
-                                    loading="lazy">
+                            <div class="carousel-slide">
+                                <img src="assets/transactions.png" alt="Transactions view" loading="lazy">
                             </div>
-                        </div>
-                        <div class="carousel-slide">
-                            <div class="carousel-img">
+                            <div class="carousel-slide">
                                 <img src="assets/projection.png" alt="Financial projection chart" loading="lazy">
                             </div>
-                        </div>
-                        <div class="carousel-slide">
-                            <div class="carousel-img">
-                                <img src="assets/breakdown.png" alt="Expense breakdown by merchant" loading="lazy">
+                            <div class="carousel-slide">
+                                <img src="assets/breakdown.png" alt="Expense breakdown" loading="lazy">
                             </div>
-                        </div>
-                        <div class="carousel-slide">
-                            <div class="carousel-img">
-                                <img src="assets/recurring.png" alt="Recurring payments tracker" loading="lazy">
+                            <div class="carousel-slide">
+                                <img src="assets/recurring.png" alt="Recurring payments" loading="lazy">
                             </div>
-                        </div>
-                        <div class="carousel-slide">
-                            <div class="carousel-img carousel-img-mobile">
+                            <div class="carousel-slide carousel-slide-mobile">
                                 <img src="assets/mobile-summary.png" alt="Mobile responsive view" loading="lazy">
                             </div>
                         </div>
                     </div>
+
+                    <button class="carousel-btn carousel-prev" aria-label="Previous slide" type="button">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2">
+                            <path d="M15 18l-6-6 6-6" />
+                        </svg>
+                    </button>
+                    <button class="carousel-btn carousel-next" aria-label="Next slide" type="button">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2">
+                            <path d="M9 18l6-6-6-6" />
+                        </svg>
+                    </button>
                 </div>
 
-                <button class="carousel-btn carousel-prev" aria-label="Previous slide">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M15 18l-6-6 6-6" />
-                    </svg>
-                </button>
-                <button class="carousel-btn carousel-next" aria-label="Next slide">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M9 18l6-6-6-6" />
-                    </svg>
-                </button>
+                <div class="carousel-meta">
+                    <div class="carousel-info">
+                        <div class="carousel-label">
+                            <span class="he" data-slide-label-he="0">סיכום חודשי</span>
+                            <span class="en" data-slide-label-en="0">Monthly summary</span>
+                        </div>
+                        <div class="carousel-desc">
+                            <span class="he" data-slide-desc-he="0">סקירה חודשית עם שימוש בכרטיסי אשראי לפי בנק, סך
+                                ההוצאה ובריאות התקציב.</span>
+                            <span class="en" data-slide-desc-en="0">Monthly overview with credit-card usage by bank,
+                                total spend, and budget health.</span>
+                        </div>
+                    </div>
 
-                <div class="carousel-info">
-                    <div class="carousel-label">Summary</div>
-                    <div class="carousel-desc">Monthly overview with credit card usage by bank, total spend tracking,
-                        and budget health.</div>
-                </div>
-
-                <div class="carousel-dots">
-                    <button class="carousel-dot active" data-slide="0" aria-label="Summary"></button>
-                    <button class="carousel-dot" data-slide="1" aria-label="Transactions"></button>
-                    <button class="carousel-dot" data-slide="2" aria-label="Projection"></button>
-                    <button class="carousel-dot" data-slide="3" aria-label="Breakdown"></button>
-                    <button class="carousel-dot" data-slide="4" aria-label="Recurring"></button>
-                    <button class="carousel-dot" data-slide="5" aria-label="Mobile"></button>
+                    <div class="carousel-dots">
+                        <button class="carousel-dot active" data-slide="0" aria-label="Slide 1" type="button"></button>
+                        <button class="carousel-dot" data-slide="1" aria-label="Slide 2" type="button"></button>
+                        <button class="carousel-dot" data-slide="2" aria-label="Slide 3" type="button"></button>
+                        <button class="carousel-dot" data-slide="3" aria-label="Slide 4" type="button"></button>
+                        <button class="carousel-dot" data-slide="4" aria-label="Slide 5" type="button"></button>
+                        <button class="carousel-dot" data-slide="5" aria-label="Slide 6" type="button"></button>
+                    </div>
                 </div>
             </div>
         </div>
     </section>
 
+    <!-- ────────────── FEATURES ────────────── -->
     <section id="features" class="section">
         <div class="container">
-            <h2 class="section-title">Everything you need</h2>
-            <p class="section-sub">A complete personal finance toolkit designed for the Israeli banking ecosystem.</p>
-
-            <div class="features-grid">
-                <div class="feature-card">
-                    <div class="feature-icon">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path
-                                d="M12 2v4m0 12v4M4.93 4.93l2.83 2.83m8.48 8.48l2.83 2.83M2 12h4m12 0h4M4.93 19.07l2.83-2.83m8.48-8.48l2.83-2.83" />
-                        </svg>
-                    </div>
-                    <h3>Automated Scraping</h3>
-                    <p>Fetches transactions from all major Israeli banks and credit card providers automatically. Set it
-                        and forget it with scheduled syncs.</p>
-                </div>
-
-                <div class="feature-card">
-                    <div class="feature-icon">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path
-                                d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-                        </svg>
-                    </div>
-                    <h3>Smart Categorization</h3>
-                    <p>Auto-categorize transactions with customizable rules. Create your own categories and let the
-                        system learn your spending patterns.</p>
-                </div>
-
-                <div class="feature-card">
-                    <div class="feature-icon">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path
-                                d="M16 8v8m-4-5v5m-4-2v2m-2 4h16a2 2 0 002-2V6a2 2 0 00-2-2H4a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                        </svg>
-                    </div>
-                    <h3>Budget Tracking</h3>
-                    <p>Set monthly budgets per category and track spending against them. Visual progress bars show
-                        exactly where you stand.</p>
-                </div>
-
-                <div class="feature-card">
-                    <div class="feature-icon">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path
-                                d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
-                        </svg>
-                    </div>
-                    <h3>WhatsApp Reports</h3>
-                    <p>Get daily or weekly spending summaries delivered straight to your WhatsApp. Stay on top of your
-                        finances without opening the app.</p>
-                </div>
-
-                <div class="feature-card">
-                    <div class="feature-icon">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path
-                                d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-                        </svg>
-                    </div>
-                    <h3>AI Assistant</h3>
-                    <p>Ask questions about your spending in natural language. Bring your own AI provider — any
-                        OpenAI-compatible API works (OpenRouter, OpenAI, Groq, Gemini, Ollama, and more).</p>
-                </div>
-
-                <div class="feature-card">
-                    <div class="feature-icon">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path
-                                d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-                            <circle cx="12" cy="12" r="3" />
-                        </svg>
-                    </div>
-                    <h3>MCP Integration</h3>
-                    <p>Model Context Protocol support lets AI tools like Claude interact with your financial data
-                        directly. The future of AI-powered finance.</p>
-                </div>
+            <div class="section-head">
+                <div class="section-eyebrow"><span class="he">יכולות</span><span class="en">Features</span></div>
+                <h2 class="section-title">
+                    <span class="he">כל מה שצריך, כלום מיותר.</span>
+                    <span class="en">Everything you need, nothing you don't.</span>
+                </h2>
+                <p class="section-sub">
+                    <span class="he">ארגז כלים לניהול פיננסי אישי, מותאם בדיוק לאיך שדברים עובדים בישראל.</span>
+                    <span class="en">A complete personal-finance toolkit, designed for the way Israeli banking actually
+                        works.</span>
+                </p>
             </div>
 
-            <div class="feature-highlight">
-                <div class="feature-highlight-content">
-                    <h3>Runs anywhere</h3>
-                    <p>
-                        Nudlers includes built-in resource optimization with two modes: <strong>normal</strong> for
-                        standard servers,
-                        and <strong>low</strong> for NAS devices, Raspberry Pi, and other minimal hardware.
-                        Your finances, your hardware, your choice.
+            <div class="features-grid">
+                <article class="feature-card">
+                    <div class="feature-icon">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7">
+                            <path d="M21 12a9 9 0 11-9-9c2.5 0 4.8 1 6.4 2.6L21 8" />
+                            <polyline points="21 3 21 8 16 8" />
+                        </svg>
+                    </div>
+                    <h3 class="feature-title">
+                        <span class="he">סריקה אוטומטית</span>
+                        <span class="en">Automated scraping</span>
+                    </h3>
+                    <p class="feature-text">
+                        <span class="he">מושך עסקאות מכל הבנקים הגדולים וחברות האשראי בישראל. הגדר פעם אחת — והשאר זוכר
+                            בלעדיך.</span>
+                        <span class="en">Pulls transactions from every major Israeli bank and card provider. Set it up
+                            once, then forget it exists.</span>
+                    </p>
+                    <div class="feature-tags">
+                        <span class="tag">Hapoalim</span><span class="tag">Leumi</span><span
+                            class="tag">Discount</span><span class="tag">VisaCal</span><span class="tag">Max</span><span
+                            class="tag">Isracard</span><span class="tag">+</span>
+                    </div>
+                </article>
+
+                <article class="feature-card">
+                    <div class="feature-icon">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7">
+                            <path d="M3 7h18M3 12h18M3 17h12" />
+                            <circle cx="19.5" cy="17" r="2.5" />
+                        </svg>
+                    </div>
+                    <h3 class="feature-title">
+                        <span class="he">קטגוריזציה חכמה</span>
+                        <span class="en">Smart categorisation</span>
+                    </h3>
+                    <p class="feature-text">
+                        <span class="he">מיון אוטומטי לפי כללים שאתה כותב בעצמך — בלי AI שמשגע אותך או חוקים שכפו עליך
+                            במקום אחר.</span>
+                        <span class="en">Auto-categorise by rules you write yourself — no opaque AI guessing, no
+                            categories someone else decided you need.</span>
+                    </p>
+                </article>
+
+                <article class="feature-card">
+                    <div class="feature-icon">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7">
+                            <path d="M3 3v18h18" />
+                            <path d="M7 14l4-4 4 4 5-7" />
+                        </svg>
+                    </div>
+                    <h3 class="feature-title">
+                        <span class="he">מעקב תקציב חודשי</span>
+                        <span class="en">Monthly budgeting</span>
+                    </h3>
+                    <p class="feature-text">
+                        <span class="he">תקציב לכל קטגוריה, פסי התקדמות ויזואליים, וחיתוך לפי מחזור החיוב — לא לפי תאריך
+                            לועזי.</span>
+                        <span class="en">Per-category budgets, visual progress bars, sliced by your billing cycle —
+                            not the calendar month.</span>
+                    </p>
+                </article>
+
+                <article class="feature-card">
+                    <div class="feature-icon">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7">
+                            <path
+                                d="M21 11.5a8.4 8.4 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.4 8.4 0 01-3.8-.9L3 21l1.9-5.7a8.4 8.4 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.4 8.4 0 013.8-.9h.5a8.5 8.5 0 018 8v.5z" />
+                        </svg>
+                    </div>
+                    <h3 class="feature-title">
+                        <span class="he">סיכומי וואטסאפ</span>
+                        <span class="en">WhatsApp summaries</span>
+                    </h3>
+                    <p class="feature-text">
+                        <span class="he">סיכום הוצאות יומי או שבועי ישר לטלפון. בלי להיכנס לאפליקציה — אתה תמיד יודע איפה
+                            אתה עומד.</span>
+                        <span class="en">Daily or weekly spend summaries straight to your phone. Stay on top of things
+                            without ever opening the app.</span>
+                    </p>
+                </article>
+
+                <article class="feature-card">
+                    <div class="feature-icon">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7">
+                            <path
+                                d="M12 2a3 3 0 013 3v6a3 3 0 11-6 0V5a3 3 0 013-3zM19 11a7 7 0 11-14 0M12 18v3M8 21h8" />
+                        </svg>
+                    </div>
+                    <h3 class="feature-title">
+                        <span class="he">עוזר AI אישי</span>
+                        <span class="en">AI assistant</span>
+                    </h3>
+                    <p class="feature-text">
+                        <span class="he">שואל שאלות על ההוצאות שלך בעברית. עובד עם כל ספק תואם OpenAI: OpenRouter,
+                            OpenAI, Groq, Gemini, Ollama מקומי — אתה בוחר.</span>
+                        <span class="en">Ask questions about your spend in plain language. Works with any
+                            OpenAI-compatible provider: OpenRouter, OpenAI, Groq, Gemini, local Ollama — your
+                            call.</span>
+                    </p>
+                </article>
+
+                <article class="feature-card">
+                    <div class="feature-icon">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7">
+                            <circle cx="12" cy="12" r="3" />
+                            <path d="M12 1v6m0 10v6M4.22 4.22l4.24 4.24m7.08 7.08l4.24 4.24M1 12h6m10 0h6" />
+                        </svg>
+                    </div>
+                    <h3 class="feature-title">
+                        <span class="he">חיבור ל-MCP</span>
+                        <span class="en">MCP integration</span>
+                    </h3>
+                    <p class="feature-text">
+                        <span class="he">תמיכה ב-Model Context Protocol — Claude וכלי AI אחרים מדברים ישירות עם הנתונים
+                            הפיננסיים שלך, בלי אמצע.</span>
+                        <span class="en">Model Context Protocol support lets Claude and other AI tools talk directly to
+                            your financial data — no middleman.</span>
+                    </p>
+                </article>
+            </div>
+        </div>
+    </section>
+
+    <!-- ────────────── SECURITY ────────────── -->
+    <section id="security" class="section">
+        <div class="container">
+            <div class="section-head">
+                <div class="section-eyebrow"><span class="he">אבטחה</span><span class="en">Security</span></div>
+                <h2 class="section-title">
+                    <span class="he">הסיסמאות שלך לא יוצאות מהמכונה.</span>
+                    <span class="en">Your passwords never leave the machine.</span>
+                </h2>
+                <p class="section-sub">
+                    <span class="he">לא לשרת ענן, לא לשירות צד-שלישי. הכול מוצפן בכספת מקומית, נפתח רק עם הסיסמה
+                        שלך.</span>
+                    <span class="en">Not to a cloud, not to a third-party service. Everything's encrypted in a local
+                        vault, unlocked only by your passphrase.</span>
+                </p>
+            </div>
+
+            <div class="security-grid">
+                <div class="security-card security-card-wide">
+                    <div class="security-flow">
+                        <div class="flow-step">
+                            <div class="flow-key">
+                                <span class="he">סיסמה</span>
+                                <span class="en">Passphrase</span>
+                            </div>
+                            <div class="flow-meta">scrypt</div>
+                        </div>
+                        <div class="flow-arrow">→</div>
+                        <div class="flow-step">
+                            <div class="flow-key">
+                                <span class="he">מפתח עיטוף</span>
+                                <span class="en">Wrapping key</span>
+                            </div>
+                            <div class="flow-meta">AES-256-GCM</div>
+                        </div>
+                        <div class="flow-arrow">→</div>
+                        <div class="flow-step">
+                            <div class="flow-key">
+                                <span class="he">מפתח מאסטר</span>
+                                <span class="en">Master key</span>
+                            </div>
+                            <div class="flow-meta">
+                                <span class="he">בזיכרון בלבד</span>
+                                <span class="en">In memory only</span>
+                            </div>
+                        </div>
+                        <div class="flow-arrow">→</div>
+                        <div class="flow-step">
+                            <div class="flow-key">
+                                <span class="he">הפרטים שלך</span>
+                                <span class="en">Your credentials</span>
+                            </div>
+                            <div class="flow-meta">
+                                <span class="he">מוצפן בבסיס הנתונים</span>
+                                <span class="en">Encrypted in DB</span>
+                            </div>
+                        </div>
+                    </div>
+                    <p class="security-explainer">
+                        <span class="he">שכבת הצפנה כפולה. גם אם בסיס הנתונים נחשף — הסיסמאות שלך נשארות חתומות. שכחת את
+                            סיסמת הכספת? אף אחד לא יכול לפתוח אותה. גם לא אנחנו.</span>
+                        <span class="en">Two-layer encryption. Even if the database leaks, your credentials stay sealed.
+                            Forget the vault passphrase? Nobody can recover it. Including us.</span>
                     </p>
                 </div>
-                <div class="resource-modes">
-                    <div class="resource-mode">
-                        <div class="resource-mode-icon">&#9881;</div>
-                        <div class="resource-mode-label">Normal</div>
-                        <div class="resource-mode-desc">2GB+ RAM servers</div>
-                    </div>
-                    <div class="resource-mode">
-                        <div class="resource-mode-icon">&#128425;</div>
-                        <div class="resource-mode-label">Low</div>
-                        <div class="resource-mode-desc">NAS &amp; Raspberry Pi</div>
+
+                <div class="security-card">
+                    <div class="security-icon">⌬</div>
+                    <h4>
+                        <span class="he">2FA מובנה</span>
+                        <span class="en">Native 2FA</span>
+                    </h4>
+                    <p>
+                        <span class="he">תמיכה מובנית באימות דו-שלבי של OneZero ובקוד OTP של בנק הפועלים — בלי לעבור דרך
+                            תוספים חיצוניים.</span>
+                        <span class="en">Native 2FA flow for OneZero and Bank Hapoalim's OTP — no third-party
+                            extension required.</span>
+                    </p>
+                </div>
+
+                <div class="security-card">
+                    <div class="security-icon">⊘</div>
+                    <h4>
+                        <span class="he">אפס טלמטריה</span>
+                        <span class="en">Zero telemetry</span>
+                    </h4>
+                    <p>
+                        <span class="he">בלי אנליטיקס, בלי שליחת לוגים החוצה, בלי "anonymized usage data". אם אתה לא
+                            רואה את זה ב-DevTools — זה לא קורה.</span>
+                        <span class="en">No analytics, no remote logs, no "anonymised usage data". If you don't see
+                            it in DevTools, it isn't happening.</span>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- ────────────── HEBREW NATIVE ────────────── -->
+    <section class="section section-hebrew">
+        <div class="container">
+            <div class="hebrew-card">
+                <div class="hebrew-card-text">
+                    <div class="section-eyebrow"><span class="he">עברית</span><span class="en">Hebrew</span></div>
+                    <h2 class="section-title">
+                        <span class="he">עברית מלאה. RTL אמיתי.</span>
+                        <span class="en">Real Hebrew. Real RTL.</span>
+                    </h2>
+                    <p class="section-sub">
+                        <span class="he">לא תרגום אוטומטי, לא RTL מאולתר. הממשק נבנה מחדש כך שהוא ירגיש טבעי — מהפינות
+                            של הכרטיסים ועד למיקום של החצים.</span>
+                        <span class="en">Not Google-translated, not bolt-on RTL. The interface was rebuilt so it
+                            actually feels right — from card corners to arrow direction.</span>
+                    </p>
+                    <ul class="hebrew-list">
+                        <li><span class="he">כיוון מסמך אוטומטי לפי שפה</span><span class="en">Document direction
+                                follows the chosen language</span></li>
+                        <li><span class="he">מספרים פיננסיים מיושרים נכון</span><span class="en">Financial numbers align
+                                correctly in both directions</span></li>
+                        <li><span class="he">מעבר חי בין עברית לאנגלית — בלי רענון</span><span class="en">Live switch
+                                between Hebrew and English — no reload</span></li>
+                    </ul>
+                </div>
+                <div class="hebrew-card-visual">
+                    <div class="hebrew-mock">
+                        <div class="hebrew-mock-num">₪12,847</div>
+                        <div class="hebrew-mock-label">
+                            <span class="he">סך ההוצאה החודשית</span>
+                            <span class="en">Total monthly spend</span>
+                        </div>
+                        <div class="hebrew-mock-bar">
+                            <div class="hebrew-mock-bar-fill"></div>
+                        </div>
+                        <div class="hebrew-mock-meta">
+                            <span><span class="he">73% מהתקציב</span><span class="en">73% of budget</span></span>
+                            <span class="hebrew-mock-trend">▲ 8%</span>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </section>
 
-    <section id="credits" class="section section-alt">
+    <!-- ────────────── RUNS ANYWHERE ────────────── -->
+    <section class="section">
         <div class="container">
-            <h2 class="section-title">Standing on the shoulders of giants</h2>
-            <p class="section-sub">Nudlers wouldn't exist without the incredible open-source community.</p>
-
-            <div class="credits-card">
-                <div class="credits-icon">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path
-                            d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
-                    </svg>
+            <div class="runs-card">
+                <div class="runs-text">
+                    <h3>
+                        <span class="he">רץ בכל מקום.</span>
+                        <span class="en">Runs anywhere.</span>
+                    </h3>
+                    <p>
+                        <span class="he">שני מצבים מובנים: <strong>normal</strong> לשרתים סטנדרטיים,
+                            <strong>low</strong> ל-NAS, רספברי פיי וכל פיסת חומרה צנועה. הפיננסים שלך, החומרה
+                            שלך.</span>
+                        <span class="en">Two built-in modes: <strong>normal</strong> for standard servers,
+                            <strong>low</strong> for NAS boxes, Raspberry Pi, and other modest hardware. Your
+                            finances, your hardware.</span>
+                    </p>
                 </div>
+                <div class="runs-modes">
+                    <div class="runs-mode">
+                        <div class="runs-mode-icon">⚙</div>
+                        <div class="runs-mode-label">normal</div>
+                        <div class="runs-mode-desc"><span class="he">2GB+ זיכרון</span><span class="en">2GB+ RAM</span>
+                        </div>
+                    </div>
+                    <div class="runs-mode">
+                        <div class="runs-mode-icon">⏻</div>
+                        <div class="runs-mode-label">low</div>
+                        <div class="runs-mode-desc"><span class="he">NAS, רספברי פיי</span><span class="en">NAS,
+                                Raspberry Pi</span></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- ────────────── CREDITS ────────────── -->
+    <section class="section">
+        <div class="container">
+            <div class="credits-card">
+                <div class="credits-icon">♥</div>
                 <h3>israeli-bank-scrapers</h3>
                 <p>
-                    A huge thank you to <a href="https://github.com/eshaham/israeli-bank-scrapers" target="_blank"
-                        rel="noopener">israeli-bank-scrapers</a> &mdash;
-                    the open-source library that makes it all possible. Thanks to their work, Nudlers supports most
-                    Israeli banks and credit card providers out of the box.
-                    If you find Nudlers useful, go give them a star too.
+                    <span class="he">תודה ענקית ל-<a href="https://github.com/eshaham/israeli-bank-scrapers"
+                            target="_blank" rel="noopener">israeli-bank-scrapers</a> —
+                        הספרייה הפתוחה שמאפשרת את כל זה. בזכות העבודה שלהם, Nudlers תומך ברוב הבנקים וחברות האשראי
+                        בישראל מהיום הראשון. אם Nudlers שימושי לך, תן להם כוכב גם.</span>
+                    <span class="en">A huge thank you to <a href="https://github.com/eshaham/israeli-bank-scrapers"
+                            target="_blank" rel="noopener">israeli-bank-scrapers</a> —
+                        the open-source library that makes all of this possible. Thanks to their work, Nudlers supports
+                        most Israeli banks and card providers out of the box. If Nudlers is useful to you, go give them
+                        a star too.</span>
                 </p>
-                <a href="https://github.com/eshaham/israeli-bank-scrapers" class="btn btn-secondary credits-btn"
-                    target="_blank" rel="noopener">
-                    <svg viewBox="0 0 24 24" fill="currentColor" width="18" height="18"
-                        style="width:18px;height:18px;margin-right:8px">
-                        <path
-                            d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
-                    </svg>
-                    israeli-bank-scrapers on GitHub
+                <a href="https://github.com/eshaham/israeli-bank-scrapers" class="btn btn-ghost btn-sm" target="_blank"
+                    rel="noopener">
+                    <span class="he">לפרויקט בגיטהאב →</span>
+                    <span class="en">Star them on GitHub →</span>
                 </a>
             </div>
         </div>
     </section>
 
-    <section id="installation" class="section">
+    <!-- ────────────── INSTALLATION ────────────── -->
+    <section id="install" class="section">
         <div class="container">
-            <h2 class="section-title">Get up and running</h2>
-            <p class="section-sub">Nudlers runs with Docker Compose. Here's everything you need.</p>
-
-            <div class="install-steps">
-                <div class="install-step">
-                    <div class="step-number">1</div>
-                    <div class="step-content">
-                        <h3>Prerequisites</h3>
-                        <ul>
-                            <li>Docker &amp; Docker Compose</li>
-                            <li>Node.js 22+ (for local development)</li>
-                            <li>PostgreSQL database</li>
-                        </ul>
-                    </div>
-                </div>
-
-                <div class="install-step">
-                    <div class="step-number">2</div>
-                    <div class="step-content">
-                        <h3>Clone the repository</h3>
-                        <div class="code-block">
-                            <pre><code>git clone https://github.com/enudler/nudlers.git
-cd nudlers</code></pre>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="install-step">
-                    <div class="step-number">3</div>
-                    <div class="step-content">
-                        <h3>Configure environment</h3>
-                        <p>Create a <code>.env</code> file in the <code>app/</code> directory:</p>
-                        <div class="code-block">
-                            <pre><code># Database
-NUDLERS_DB_USER=nudlers
-NUDLERS_DB_HOST=localhost
-NUDLERS_DB_NAME=nudlers
-NUDLERS_DB_PASSWORD=your_secure_password
-NUDLERS_DB_PORT=5432
-
-# Vault: configured automatically via the UI on first run
-
-# Resource Mode (normal | low)
-RESOURCE_MODE=normal
-
-# Optional: AI Assistant (any OpenAI-compatible provider)
-AI_BASE_URL=https://openrouter.ai/api/v1
-AI_API_KEY=your_provider_api_key
-AI_MODEL=google/gemini-2.5-flash</code></pre>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="install-step">
-                    <div class="step-number">4</div>
-                    <div class="step-content">
-                        <h3>Install and run</h3>
-                        <div class="code-block">
-                            <pre><code>cd app
-npm install
-npm run dev</code></pre>
-                        </div>
-                        <p>The app will be available at <code>http://localhost:6969</code></p>
-                    </div>
-                </div>
+            <div class="section-head">
+                <div class="section-eyebrow"><span class="he">התקנה</span><span class="en">Install</span></div>
+                <h2 class="section-title">
+                    <span class="he">בארבעה צעדים, על השרת שלך.</span>
+                    <span class="en">Four steps, on your own server.</span>
+                </h2>
+                <p class="section-sub">
+                    <span class="he">Docker Compose, קובץ env אחד, ויש לך את הכול.</span>
+                    <span class="en">Docker Compose, one env file, and you're up.</span>
+                </p>
             </div>
-        </div>
-    </section>
 
-    <section id="configuration" class="section section-alt">
-        <div class="container">
-            <h2 class="section-title">Configuration</h2>
-            <p class="section-sub">Fine-tune Nudlers to match your setup and preferences.</p>
-
-            <div class="config-grid">
-                <div class="config-card">
-                    <h3>Resource Modes</h3>
-                    <p>Optimize performance based on your hardware:</p>
-                    <table class="config-table">
-                        <thead>
-                            <tr>
-                                <th>Mode</th>
-                                <th>Target Hardware</th>
-                                <th>RAM</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td><code>normal</code></td>
-                                <td>Standard servers, desktops</td>
-                                <td>2GB+</td>
-                            </tr>
-                            <tr>
-                                <td><code>low</code></td>
-                                <td>NAS, Raspberry Pi</td>
-                                <td>512MB+</td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-
-                <div class="config-card">
-                    <h3>Billing Cycle</h3>
-                    <p>
-                        Israeli credit card billing cycles don't align with calendar months.
-                        Nudlers groups transactions by billing cycle (default: 10th of each month)
-                        so your spending view matches your actual statements.
-                    </p>
-                    <p>Configurable via <strong>Settings &rarr; Billing Cycle Start Day</strong>.</p>
-                </div>
-
-                <div class="config-card">
-                    <h3>WhatsApp Notifications</h3>
-                    <p>Get automated spending summaries delivered to WhatsApp:</p>
+            <div class="install-grid">
+                <div class="install-step">
+                    <div class="step-num">01</div>
+                    <h3>
+                        <span class="he">דרישות מקדימות</span>
+                        <span class="en">Prerequisites</span>
+                    </h3>
                     <ul>
-                        <li>Daily or weekly summary modes</li>
-                        <li>Configurable send time</li>
-                        <li>Category breakdown included</li>
+                        <li><bdi>Docker &amp; Docker Compose</bdi></li>
+                        <li><bdi>Node.js 22+</bdi></li>
+                        <li><bdi>PostgreSQL</bdi></li>
                     </ul>
                 </div>
 
-                <div class="config-card">
-                    <h3>Scheduled Sync</h3>
-                    <p>
-                        Set up automatic transaction fetching on a schedule. Configure sync frequency,
-                        days to look back, and which accounts to include. Credentials are encrypted at rest
-                        with AES-256.
+                <div class="install-step">
+                    <div class="step-num">02</div>
+                    <h3>
+                        <span class="he">שכפול הריפוזיטורי</span>
+                        <span class="en">Clone the repo</span>
+                    </h3>
+                    <pre><code>git clone https://github.com/enudler/nudlers.git
+cd nudlers</code></pre>
+                </div>
+
+                <div class="install-step">
+                    <div class="step-num">03</div>
+                    <h3>
+                        <span class="he">קובץ סביבה</span>
+                        <span class="en">Environment file</span>
+                    </h3>
+                    <pre><code>NUDLERS_DB_USER=nudlers
+NUDLERS_DB_HOST=localhost
+NUDLERS_DB_NAME=nudlers
+NUDLERS_DB_PASSWORD=secret
+NUDLERS_DB_PORT=5432
+
+RESOURCE_MODE=normal
+
+# AI (optional)
+AI_BASE_URL=https://openrouter.ai/api/v1
+AI_API_KEY=...
+AI_MODEL=google/gemini-2.5-flash</code></pre>
+                </div>
+
+                <div class="install-step">
+                    <div class="step-num">04</div>
+                    <h3>
+                        <span class="he">להריץ</span>
+                        <span class="en">Run it</span>
+                    </h3>
+                    <pre><code>cd app
+npm install
+npm run dev</code></pre>
+                    <p class="install-foot">
+                        <span class="he">זמין ב-<code>http://localhost:6969</code></span>
+                        <span class="en">Available at <code>http://localhost:6969</code></span>
                     </p>
                 </div>
             </div>
         </div>
     </section>
 
-    <section class="section tech-section">
+    <!-- ────────────── TECH STACK ────────────── -->
+    <section class="section">
         <div class="container">
-            <h2 class="section-title">Built with</h2>
-            <div class="tech-grid">
-                <div class="tech-item">Next.js</div>
-                <div class="tech-item">TypeScript</div>
-                <div class="tech-item">PostgreSQL</div>
-                <div class="tech-item">Material UI</div>
-                <div class="tech-item">Puppeteer</div>
-                <div class="tech-item">Pino</div>
-                <div class="tech-item">Vitest</div>
-                <div class="tech-item">Docker</div>
+            <div class="section-head">
+                <h2 class="section-title section-title-sm">
+                    <span class="he">בנוי עם</span>
+                    <span class="en">Built with</span>
+                </h2>
+            </div>
+            <div class="tech-row">
+                <span class="tech-pill">Next.js</span>
+                <span class="tech-pill">TypeScript</span>
+                <span class="tech-pill">PostgreSQL</span>
+                <span class="tech-pill">Material UI</span>
+                <span class="tech-pill">Puppeteer</span>
+                <span class="tech-pill">Pino</span>
+                <span class="tech-pill">Vitest</span>
+                <span class="tech-pill">Docker</span>
+                <span class="tech-pill">i18next</span>
             </div>
         </div>
     </section>
 
-    <section id="faq" class="section section-alt">
-        <div class="container">
-            <h2 class="section-title">Frequently Asked Questions</h2>
-            <p class="section-sub">Got questions? We've got answers.</p>
+    <!-- ────────────── FAQ ────────────── -->
+    <section id="faq" class="section">
+        <div class="container container-narrow">
+            <div class="section-head">
+                <div class="section-eyebrow"><span class="he">שאלות נפוצות</span><span class="en">FAQ</span></div>
+                <h2 class="section-title">
+                    <span class="he">שאלות, ותשובות.</span>
+                    <span class="en">Questions, answered.</span>
+                </h2>
+            </div>
 
             <div class="faq-list">
                 <details class="faq-item">
-                    <summary class="faq-question">Why would I need Nudlers?</summary>
-                    <div class="faq-answer">
-                        <p>
-                            If you have multiple bank accounts or multiple credit cards in your household, things get
-                            complicated fast.
-                            You want to coordinate spending across all of them, set budgets, and understand how your
-                            bank accounts
-                            are going to look at a specific date after all pending credit card charges settle.
+                    <summary>
+                        <span class="he">בשביל מה אני צריך את Nudlers?</span>
+                        <span class="en">Why would I need Nudlers?</span>
+                    </summary>
+                    <div class="faq-body">
+                        <p><span class="he">אם יש לך כמה חשבונות בנק או כמה כרטיסי אשראי במשפחה, הדברים מסתבכים מהר. אתה
+                                רוצה לתאם הוצאות, לקבוע תקציבים, ולהבין איך החשבון שלך הולך להיראות בעוד שבועיים אחרי
+                                שכל החיובים יבואו.</span>
+                            <span class="en">If you've got more than one bank account or more than one card in the
+                                household, things get hairy fast. You want to coordinate spending, set budgets, and
+                                understand what your balance will look like in two weeks once all the pending charges
+                                land.</span>
                         </p>
-                        <p>
-                            Nudlers gives you a single, unified view of all your accounts &mdash; even when you have
-                            several
-                            credit cards and bank accounts spread across the family. One dashboard, full visibility.
-                        </p>
-                    </div>
-                </details>
-
-                <details class="faq-item">
-                    <summary class="faq-question">How does the data get into the app?</summary>
-                    <div class="faq-answer">
-                        <p>
-                            Nudlers uses the open-source
-                            <a href="https://github.com/eshaham/israeli-bank-scrapers" target="_blank"
-                                rel="noopener">israeli-bank-scrapers</a>
-                            library. You provide your bank and credit card credentials, and the library logs into your
-                            accounts to fetch your transactions automatically. The scraping runs locally on your own
-                            machine &mdash;
-                            no third-party servers involved.
+                        <p><span class="he">Nudlers נותן לך תמונה אחת — גם כשיש כמה כרטיסים וכמה חשבונות פזורים. דשבורד
+                                אחד, נראות מלאה.</span>
+                            <span class="en">Nudlers gives you one view — even when you have several cards and accounts
+                                spread around. One dashboard, full visibility.</span>
                         </p>
                     </div>
                 </details>
 
                 <details class="faq-item">
-                    <summary class="faq-question">Is my data safe? Who can see it?</summary>
-                    <div class="faq-answer">
-                        <p>
-                            Nobody can see your data. Nudlers is a fully self-hosted, local-only application. Your
-                            financial
-                            data never leaves your machine. There are no cloud servers, no analytics, no external data
-                            transmission. It's your data on your hardware &mdash; period.
+                    <summary>
+                        <span class="he">איך הנתונים מגיעים לאפליקציה?</span>
+                        <span class="en">How does the data get in?</span>
+                    </summary>
+                    <div class="faq-body">
+                        <p><span class="he">Nudlers משתמש בספריית הקוד הפתוח <a
+                                    href="https://github.com/eshaham/israeli-bank-scrapers" target="_blank"
+                                    rel="noopener">israeli-bank-scrapers</a>. אתה נותן לאפליקציה את פרטי ההתחברות שלך,
+                                והיא נכנסת לחשבונות שלך בעצמה ומושכת את העסקאות. כל הסריקה רצה אצלך מקומית — אין שרת
+                                שלישי במשחק.</span>
+                            <span class="en">Nudlers uses the open-source <a
+                                    href="https://github.com/eshaham/israeli-bank-scrapers" target="_blank"
+                                    rel="noopener">israeli-bank-scrapers</a> library. You give it your bank and card
+                                credentials and it logs in on your behalf to fetch transactions. Everything runs
+                                locally on your machine — no third-party servers involved.</span>
                         </p>
                     </div>
                 </details>
 
                 <details class="faq-item">
-                    <summary class="faq-question">How are my bank credentials stored?</summary>
-                    <div class="faq-answer">
-                        <p>
-                            Your credentials are stored encrypted in the database using AES-256-GCM encryption.
-                            Nudlers uses a two-layer encryption model: a random master key encrypts your
-                            credentials, and that master key is itself encrypted by a key derived from your
-                            vault passphrase. Even if your database is compromised, credentials remain secure
-                            because the master key is never stored in plain form — only its encrypted version is.
+                    <summary>
+                        <span class="he">הנתונים שלי בטוחים? מי רואה אותם?</span>
+                        <span class="en">Is my data safe? Who can see it?</span>
+                    </summary>
+                    <div class="faq-body">
+                        <p><span class="he">אף אחד לא רואה את הנתונים שלך. Nudlers הוא Self-hosted לחלוטין. אין שרת
+                                ענן, אין אנליטיקס, אין שום דבר שיוצא החוצה. הנתונים שלך, על השרת שלך — נקודה.</span>
+                            <span class="en">Nobody sees your data. Nudlers is fully self-hosted. There are no cloud
+                                servers, no analytics, no external transmission. It's your data on your hardware —
+                                full stop.</span>
                         </p>
                     </div>
                 </details>
 
                 <details class="faq-item">
-                    <summary class="faq-question">What does the vault passphrase protect, and is it stored anywhere?</summary>
-                    <div class="faq-answer">
-                        <p>
-                            The passphrase is <strong>never stored</strong>. Instead, it is used to derive a
-                            wrapping key (via scrypt, a memory-hard key derivation function) that encrypts the
-                            master key. The full chain looks like this:
-                        </p>
-                        <pre style="background:var(--bg-surface,#1e1e2e);border-radius:8px;padding:1rem;font-size:0.82rem;overflow-x:auto;margin:0.75rem 0;">Passphrase ──scrypt──▶ Wrapping Key
-Wrapping Key ─AES-256-GCM─▶ Master Key (stored encrypted in DB)
-Master Key ─AES-256-GCM─▶ Your credentials (stored encrypted in DB)</pre>
-                        <p>
-                            Once you unlock the vault, the master key is decrypted into server memory only —
-                            it is never written to disk. It is cleared automatically when the server restarts,
-                            requiring you to unlock again. If you forget your passphrase, the master key (and
-                            everything it protects) becomes permanently inaccessible.
-                        </p>
-                    </div>
-                </details>
-
-                <details class="faq-item">
-                    <summary class="faq-question">Do I need an AI API key?</summary>
-                    <div class="faq-answer">
-                        <p>
-                            No, an AI API key is optional. AI is used only for two features:
-                            chatting with AI about your own data in the app, and preparing the WhatsApp daily message.
-                            If you don't plan to use these features, you don't need a key.
-                        </p>
-                        <p>
-                            Nudlers works with any OpenAI-compatible provider — OpenRouter (default), OpenAI, Groq,
-                            Together, Google Gemini, or self-hosted setups like LMStudio and Ollama. Configure the
-                            base URL, API key, and model slug in <strong>Settings → AI Provider</strong>.
-                        </p>
-                        <p>
-                            For deeper integration, the recommended approach is to use Nudlers through MCP
-                            (Model Context Protocol), which allows AI tools like Claude to interact with your
-                            financial data directly.
+                    <summary>
+                        <span class="he">איך נשמרים הסיסמאות שלי לבנק?</span>
+                        <span class="en">How are my bank credentials stored?</span>
+                    </summary>
+                    <div class="faq-body">
+                        <p><span class="he">הסיסמאות מוצפנות בבסיס הנתונים בהצפנת AES-256-GCM. Nudlers משתמש במודל
+                                הצפנה דו-שכבתי: מפתח מאסטר אקראי מצפין את הסיסמאות שלך, והמפתח עצמו מוצפן באמצעות מפתח
+                                שנגזר מסיסמת הכספת. גם אם בסיס הנתונים נחשף — הסיסמאות נשארות מאובטחות, כי המפתח לא
+                                נשמר בצורה גלויה לעולם.</span>
+                            <span class="en">Credentials are stored encrypted in the database using AES-256-GCM. Nudlers
+                                uses a two-layer model: a random master key encrypts your credentials, and that master
+                                key is itself encrypted by a key derived from your vault passphrase. Even if the
+                                database leaks, credentials remain secure because the master key is never written to
+                                disk in plaintext.</span>
                         </p>
                     </div>
                 </details>
 
                 <details class="faq-item">
-                    <summary class="faq-question">Why am I getting Isracard scraping errors?</summary>
-                    <div class="faq-answer">
-                        <p>
-                            Isracard has rate-limiting mechanisms that detect automated access. The scraper can fetch
-                            your transactions list, but to retrieve the category for each transaction, it needs to
-                            query them one by one. When you scrape a large date range, there are many transactions,
-                            and the category lookups can trigger rate limiting.
+                    <summary>
+                        <span class="he">מה סיסמת הכספת מגנה עליו, והאם היא נשמרת?</span>
+                        <span class="en">What does the vault passphrase protect, and is it stored anywhere?</span>
+                    </summary>
+                    <div class="faq-body">
+                        <p><span class="he">הסיסמה <strong>אף פעם לא נשמרת</strong>. במקום זה, היא משמשת לגזירת מפתח
+                                עיטוף (באמצעות scrypt — פונקציית גזירה שדורשת זיכרון) שמצפין את מפתח המאסטר.</span>
+                            <span class="en">The passphrase is <strong>never stored</strong>. Instead, it's used to
+                                derive a wrapping key (via scrypt, a memory-hard KDF) that encrypts the master
+                                key.</span>
                         </p>
-                        <p>
-                            <strong>Tip:</strong> When you start seeing errors, minimize the date range you're scraping.
-                            Shorter periods mean fewer transactions and fewer category requests, which keeps you under
-                            the rate limit.
-                        </p>
-                        <p>
-                            Nudlers also maintains a prefilled card that caches business-to-category mappings,
-                            so matching happens faster and reduces the number of requests needed over time.
-                        </p>
-                    </div>
-                </details>
-
-                <details class="faq-item">
-                    <summary class="faq-question">How are WhatsApp messages sent?</summary>
-                    <div class="faq-answer">
-                        <p>
-                            Nudlers uses the
-                            <a href="https://github.com/pedroslopez/whatsapp-web.js" target="_blank"
-                                rel="noopener">whatsapp-web.js</a>
-                            package. Under the hood, it runs a headless browser that connects to WhatsApp Web
-                            and utilizes your session to send messages. You scan a QR code once to link it,
-                            and then reports are delivered automatically.
+                        <pre class="faq-pre"><code>Passphrase ──scrypt──▶ Wrapping Key
+Wrapping Key ─AES-256-GCM─▶ Master Key  (encrypted in DB)
+Master Key  ─AES-256-GCM─▶ Credentials  (encrypted in DB)</code></pre>
+                        <p><span class="he">ברגע שאתה פותח את הכספת, מפתח המאסטר נטען לזיכרון השרת בלבד — לעולם לא
+                                נכתב לדיסק, ונמחק כשהשרת עולה מחדש. אם שכחת את הסיסמה, מפתח המאסטר (ויחד איתו כל מה
+                                שהוא מצפין) הופך בלתי נגיש לצמיתות.</span>
+                            <span class="en">Once you unlock the vault, the master key is decrypted into server memory
+                                only — never written to disk, and cleared when the server restarts. Forget the
+                                passphrase, and the master key (and everything it protects) becomes permanently
+                                inaccessible.</span>
                         </p>
                     </div>
                 </details>
 
                 <details class="faq-item">
-                    <summary class="faq-question">Who is behind Nudlers?</summary>
-                    <div class="faq-answer">
-                        <p>
-                            It's just me, <a href="https://www.linkedin.com/in/eli-nudler/" target="_blank"
-                                rel="noopener">Eli Nudler</a>. I built Nudlers to scratch my own itch managing finances
-                            across
-                            multiple Israeli bank accounts and credit cards. It's open source and free to use.
+                    <summary>
+                        <span class="he">חייב מפתח AI?</span>
+                        <span class="en">Do I need an AI API key?</span>
+                    </summary>
+                    <div class="faq-body">
+                        <p><span class="he">לא, מפתח AI הוא רשות. הוא משמש רק לשני דברים: צ'אט עם AI על הנתונים שלך,
+                                והכנת הודעת הסיכום היומית בוואטסאפ. אם לא תשתמש באלה — אין צורך במפתח.</span>
+                            <span class="en">No, an AI key is optional. It's used only for two features: chatting with
+                                AI about your own data, and composing the daily WhatsApp message. If you don't plan
+                                to use these, you don't need a key.</span>
+                        </p>
+                        <p><span class="he">Nudlers עובד עם כל ספק תואם OpenAI — OpenRouter (ברירת המחדל), OpenAI, Groq,
+                                Together, Google Gemini, או הגדרות מקומיות כמו LMStudio ו-Ollama. את ה-base URL,
+                                המפתח ושם המודל קובעים ב-<strong>Settings → AI Provider</strong>.</span>
+                            <span class="en">Nudlers works with any OpenAI-compatible provider — OpenRouter (default),
+                                OpenAI, Groq, Together, Google Gemini, or self-hosted setups like LMStudio and Ollama.
+                                Configure the base URL, API key, and model in <strong>Settings → AI
+                                    Provider</strong>.</span>
+                        </p>
+                    </div>
+                </details>
+
+                <details class="faq-item">
+                    <summary>
+                        <span class="he">למה אני מקבל שגיאות סריקה מ-Isracard?</span>
+                        <span class="en">Why am I getting Isracard scraping errors?</span>
+                    </summary>
+                    <div class="faq-body">
+                        <p><span class="he">ל-Isracard יש מנגנוני הגבלת קצב שמזהים גישה אוטומטית. הסקרייפר יכול להביא
+                                את רשימת העסקאות, אבל כדי לקבל את הקטגוריה של כל אחת — צריך לבקש אותן אחת-אחת. בטווח
+                                תאריכים גדול זה הרבה בקשות, וזה יכול להפעיל את ההגבלה.</span>
+                            <span class="en">Isracard has rate-limiting that detects automated access. The scraper can
+                                fetch the transaction list, but per-transaction category lookups happen one by one.
+                                Over a wide date range that's a lot of requests, which can trigger the limit.</span>
+                        </p>
+                        <p><span class="he"><strong>טיפ:</strong> כשהשגיאות מתחילות, צמצם את טווח התאריכים. פחות
+                                עסקאות, פחות בקשות — וזה משאיר אותך מתחת לגבול.</span>
+                            <span class="en"><strong>Tip:</strong> when errors start, narrow your date range. Fewer
+                                transactions means fewer category requests, which keeps you below the limit.</span>
+                        </p>
+                    </div>
+                </details>
+
+                <details class="faq-item">
+                    <summary>
+                        <span class="he">איך נשלחות הודעות הוואטסאפ?</span>
+                        <span class="en">How are WhatsApp messages sent?</span>
+                    </summary>
+                    <div class="faq-body">
+                        <p><span class="he">Nudlers משתמש בחבילה <a
+                                    href="https://github.com/pedroslopez/whatsapp-web.js" target="_blank"
+                                    rel="noopener">whatsapp-web.js</a>. מאחורי הקלעים רץ דפדפן ללא ממשק שמתחבר
+                                ל-WhatsApp Web ומשתמש ב-session שלך כדי לשלוח הודעות. סורקים QR פעם אחת, ומאז הסיכומים
+                                נשלחים אוטומטית.</span>
+                            <span class="en">Nudlers uses the <a href="https://github.com/pedroslopez/whatsapp-web.js"
+                                    target="_blank" rel="noopener">whatsapp-web.js</a> package. Under the hood, a
+                                headless browser connects to WhatsApp Web and uses your session to send messages. Scan
+                                a QR once to link it, then summaries flow automatically.</span>
+                        </p>
+                    </div>
+                </details>
+
+                <details class="faq-item">
+                    <summary>
+                        <span class="he">מי עומד מאחורי Nudlers?</span>
+                        <span class="en">Who's behind Nudlers?</span>
+                    </summary>
+                    <div class="faq-body">
+                        <p><span class="he">רק אני, <a href="https://www.linkedin.com/in/eli-nudler/" target="_blank"
+                                    rel="noopener">אלי נודלר</a>. בניתי את Nudlers כדי לפתור צרכים שלי בניהול הפיננסים
+                                בין כמה חשבונות וכרטיסים בישראל. הקוד פתוח וחופשי לשימוש.</span>
+                            <span class="en">It's just me, <a href="https://www.linkedin.com/in/eli-nudler/"
+                                    target="_blank" rel="noopener">Eli Nudler</a>. I built Nudlers to scratch my own
+                                itch managing finances across several Israeli accounts and cards. It's open source
+                                and free to use.</span>
                         </p>
                     </div>
                 </details>
@@ -569,80 +867,110 @@ Master Key ─AES-256-GCM─▶ Your credentials (stored encrypted in DB)</pre>
         </div>
     </section>
 
+    <!-- ────────────── FOOTER ────────────── -->
     <footer class="footer">
         <div class="container">
             <div class="footer-inner">
                 <div class="footer-brand">
                     <div class="footer-logo">
-                        <img src="assets/icon.svg" alt="Nudlers" class="nav-logo-img">
+                        <img src="assets/icon.svg" alt="Nudlers">
                         <span>Nudlers</span>
                     </div>
-                    <p>Self-hosted personal finance for Israeli banks.</p>
+                    <p>
+                        <span class="he">פיננסים אישיים, מקומיים, פתוחים.</span>
+                        <span class="en">Self-hosted personal finance, the open way.</span>
+                    </p>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/enudler/nudlers" target="_blank" rel="noopener">GitHub</a>
-                    <a href="https://github.com/enudler/nudlers/issues" target="_blank" rel="noopener">Issues</a>
+                    <a href="https://github.com/enudler/nudlers/issues" target="_blank" rel="noopener"><span
+                            class="he">בעיות</span><span class="en">Issues</span></a>
                     <a href="https://github.com/enudler/nudlers/blob/main/LICENSE" target="_blank"
                         rel="noopener">License</a>
                 </div>
             </div>
             <div class="footer-bottom">
-                <p>&copy; 2025 Nudlers. Open source under MIT License.</p>
+                <p>© 2025 Nudlers · MIT License</p>
             </div>
         </div>
     </footer>
 
+    <!-- ────────────── SCRIPTS ────────────── -->
     <script>
-        // Mobile nav toggle
-        const toggle = document.querySelector('.nav-toggle');
-        const links = document.querySelector('.nav-links');
-        toggle.addEventListener('click', () => {
-            links.classList.toggle('open');
-            toggle.classList.toggle('open');
+        // ── Language toggle ──
+        const root = document.documentElement;
+        const langButtons = document.querySelectorAll('[data-lang-set]');
+
+        function setLang(lang) {
+            if (lang !== 'he' && lang !== 'en') return;
+            root.lang = lang;
+            root.dir = lang === 'he' ? 'rtl' : 'ltr';
+            root.dataset.lang = lang;
+            try { localStorage.setItem('nudlers-lang', lang); } catch (_) { }
+            updateCarouselText();
+        }
+
+        document.querySelector('.lang-toggle').addEventListener('click', () => {
+            setLang(root.dataset.lang === 'he' ? 'en' : 'he');
         });
 
-        document.querySelectorAll('.nav-links a').forEach(link => {
-            link.addEventListener('click', () => {
-                links.classList.remove('open');
-                toggle.classList.remove('open');
+        // ── Mobile nav ──
+        const navToggle = document.querySelector('.nav-toggle');
+        const navLinks = document.querySelector('.nav-links');
+        navToggle.addEventListener('click', () => {
+            navLinks.classList.toggle('open');
+            navToggle.classList.toggle('open');
+        });
+        document.querySelectorAll('.nav-links a').forEach(a => {
+            a.addEventListener('click', () => {
+                navLinks.classList.remove('open');
+                navToggle.classList.remove('open');
             });
         });
 
-        // Sticky nav background
-        const nav = document.querySelector('.nav');
-        window.addEventListener('scroll', () => {
-            nav.classList.toggle('scrolled', window.scrollY > 20);
-        });
+        // ── Sticky nav background ──
+        const navEl = document.querySelector('.nav');
+        const handleScroll = () => navEl.classList.toggle('scrolled', window.scrollY > 24);
+        window.addEventListener('scroll', handleScroll, { passive: true });
+        handleScroll();
 
-        // Smooth scroll
-        document.querySelectorAll('a[href^="#"]').forEach(anchor => {
-            anchor.addEventListener('click', function (e) {
+        // ── Smooth scroll ──
+        document.querySelectorAll('a[href^="#"]').forEach(a => {
+            a.addEventListener('click', e => {
+                const target = document.querySelector(a.getAttribute('href'));
+                if (!target) return;
                 e.preventDefault();
-                const target = document.querySelector(this.getAttribute('href'));
-                if (target) {
-                    target.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                }
+                target.scrollIntoView({ behavior: 'smooth', block: 'start' });
             });
         });
 
         // ── Carousel ──
-        const slideData = [
-            { label: 'Summary', desc: 'Monthly overview with credit card usage by bank, total spend tracking, and budget health.' },
-            { label: 'Transactions', desc: 'View and manage all your bank and credit card transactions with search, sort, and category filtering.' },
-            { label: 'Financial Forecast', desc: '30-day balance projection with upcoming credit card settlements and recurring payments.' },
-            { label: 'Breakdown', desc: 'Detailed expense analysis grouped by merchant with quick category editing.' },
-            { label: 'Recurring Payments', desc: 'Track installments, subscriptions, and recurring charges with progress indicators.' },
-            { label: 'Mobile Friendly', desc: 'Fully responsive design that works great on phones, tablets, and desktops.' },
+        const slideMeta = [
+            { he: ['סיכום חודשי', 'סקירה חודשית עם שימוש בכרטיסי אשראי לפי בנק, סך ההוצאה ובריאות התקציב.'], en: ['Monthly summary', 'Monthly overview with credit-card usage by bank, total spend, and budget health.'] },
+            { he: ['עסקאות', 'תצוגה וניהול של כל עסקאות הבנק והאשראי, עם חיפוש, מיון וסינון לפי קטגוריה.'], en: ['Transactions', 'View and manage every bank and card transaction, with search, sort, and category filters.'] },
+            { he: ['תחזית פיננסית', 'תחזית יתרה ל-30 יום קדימה כולל חיובי אשראי וחיובים חוזרים.'], en: ['Financial forecast', '30-day balance projection including pending card settlements and recurring charges.'] },
+            { he: ['פירוק לפי בית עסק', 'ניתוח מפורט של ההוצאות מקובץ לפי בית עסק עם עריכת קטגוריה מהירה.'], en: ['Merchant breakdown', 'Detailed expense analysis grouped by merchant with quick category editing.'] },
+            { he: ['תשלומים חוזרים', 'מעקב אחרי הוראות קבע, תשלומים ומנויים — עם סרגל התקדמות.'], en: ['Recurring payments', 'Track standing orders, instalments, and subscriptions with progress indicators.'] },
+            { he: ['מותאם למובייל', 'עיצוב רספונסיבי שעובד נהדר על טלפון, טאבלט ודסקטופ.'], en: ['Mobile friendly', 'Fully responsive design that works great on phones, tablets, and desktops.'] },
         ];
 
         const slides = document.querySelectorAll('.carousel-slide');
         const dots = document.querySelectorAll('.carousel-dot');
         const prevBtn = document.querySelector('.carousel-prev');
         const nextBtn = document.querySelector('.carousel-next');
-        const labelEl = document.querySelector('.carousel-label');
-        const descEl = document.querySelector('.carousel-desc');
+        const labelHe = document.querySelector('[data-slide-label-he]');
+        const labelEn = document.querySelector('[data-slide-label-en]');
+        const descHe = document.querySelector('[data-slide-desc-he]');
+        const descEn = document.querySelector('[data-slide-desc-en]');
         let current = 0;
         let autoTimer = null;
+
+        function updateCarouselText() {
+            labelHe.textContent = slideMeta[current].he[0];
+            labelEn.textContent = slideMeta[current].en[0];
+            descHe.textContent = slideMeta[current].he[1];
+            descEn.textContent = slideMeta[current].en[1];
+        }
 
         function goTo(idx) {
             slides[current].classList.remove('active');
@@ -650,40 +978,39 @@ Master Key ─AES-256-GCM─▶ Your credentials (stored encrypted in DB)</pre>
             current = (idx + slides.length) % slides.length;
             slides[current].classList.add('active');
             dots[current].classList.add('active');
-            labelEl.textContent = slideData[current].label;
-            descEl.textContent = slideData[current].desc;
+            updateCarouselText();
             resetAuto();
         }
 
         function resetAuto() {
             clearInterval(autoTimer);
-            autoTimer = setInterval(() => goTo(current + 1), 6000);
+            autoTimer = setInterval(() => goTo(current + 1), 6500);
         }
 
         prevBtn.addEventListener('click', () => goTo(current - 1));
         nextBtn.addEventListener('click', () => goTo(current + 1));
-        dots.forEach(dot => {
-            dot.addEventListener('click', () => goTo(Number(dot.dataset.slide)));
+        dots.forEach(d => d.addEventListener('click', () => goTo(Number(d.dataset.slide))));
+
+        document.querySelector('.carousel').addEventListener('keydown', e => {
+            // Mirror arrow direction: in RTL, ArrowLeft means "next"
+            const rtl = root.dir === 'rtl';
+            if (e.key === 'ArrowLeft') goTo(rtl ? current + 1 : current - 1);
+            if (e.key === 'ArrowRight') goTo(rtl ? current - 1 : current + 1);
         });
 
-        // Keyboard navigation
-        document.querySelector('.carousel').addEventListener('keydown', (e) => {
-            if (e.key === 'ArrowLeft') goTo(current - 1);
-            if (e.key === 'ArrowRight') goTo(current + 1);
-        });
-
-        // Touch/swipe support
+        // Touch
         let touchStartX = 0;
         const viewport = document.querySelector('.carousel-viewport');
-        viewport.addEventListener('touchstart', (e) => { touchStartX = e.touches[0].clientX; }, { passive: true });
-        viewport.addEventListener('touchend', (e) => {
+        viewport.addEventListener('touchstart', e => { touchStartX = e.touches[0].clientX; }, { passive: true });
+        viewport.addEventListener('touchend', e => {
             const diff = touchStartX - e.changedTouches[0].clientX;
-            if (Math.abs(diff) > 50) {
-                diff > 0 ? goTo(current + 1) : goTo(current - 1);
-            }
+            if (Math.abs(diff) < 50) return;
+            const rtl = root.dir === 'rtl';
+            if (diff > 0) goTo(rtl ? current - 1 : current + 1);
+            else goTo(rtl ? current + 1 : current - 1);
         });
 
-        // Start auto-advance
+        updateCarouselText();
         resetAuto();
     </script>
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,197 +1,436 @@
-/* ── Reset & Base ────────────────────────────────────────── */
+/* ═════════════════════════════════════════════════════════════════
+   NUDLERS · Aurora glass theme
+   Hebrew-first (RTL), English secondary (LTR)
+   ═════════════════════════════════════════════════════════════════ */
 
+/* ── Reset & base ───────────────────────────────────────────────── */
 *,
 *::before,
 *::after {
-    margin: 0;
-    padding: 0;
     box-sizing: border-box;
 }
 
-:root {
-    --bg: #0a0a0f;
-    --bg-alt: #0f0f18;
-    --surface: #16161f;
-    --surface-hover: #1e1e2a;
-    --border: #2a2a3a;
-    --text: #e4e4ec;
-    --text-muted: #9090a8;
-    --primary: #6366f1;
-    --primary-light: #818cf8;
-    --primary-dark: #4f46e5;
-    --gradient: linear-gradient(135deg, #6366f1, #a855f7, #ec4899);
-    --gradient-subtle: linear-gradient(135deg, rgba(99, 102, 241, 0.15), rgba(168, 85, 247, 0.08));
-    --radius: 12px;
-    --radius-sm: 8px;
-    --radius-lg: 16px;
-    --nav-height: 64px;
+html,
+body {
+    margin: 0;
+    padding: 0;
+    background: var(--bg);
+    color: var(--text);
 }
 
 html {
     scroll-behavior: smooth;
-    scroll-padding-top: 70px;
+    -webkit-text-size-adjust: 100%;
 }
 
-body {
-    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    background: var(--bg);
-    color: var(--text);
-    line-height: 1.6;
-    -webkit-font-smoothing: antialiased;
+img {
+    max-width: 100%;
+    display: block;
 }
 
 a {
-    color: var(--primary-light);
+    color: inherit;
     text-decoration: none;
-    transition: color 0.2s;
 }
 
-a:hover {
-    color: var(--primary);
-}
-
-code {
-    font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
-    background: var(--surface);
-    padding: 2px 6px;
-    border-radius: 4px;
-    font-size: 0.9em;
+button {
+    font: inherit;
+    color: inherit;
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+    padding: 0;
 }
 
 ul {
     list-style: none;
-    padding-left: 0;
+    padding: 0;
+    margin: 0;
 }
 
-ul li {
-    position: relative;
-    padding-left: 1.2em;
+/* ── Tokens ─────────────────────────────────────────────────────── */
+:root {
+    /* Surface */
+    --bg: #07070d;
+    --bg-soft: #0d0d18;
+    --glass: rgba(255, 255, 255, 0.035);
+    --glass-strong: rgba(255, 255, 255, 0.06);
+    --border: rgba(255, 255, 255, 0.08);
+    --border-bright: rgba(255, 255, 255, 0.18);
+
+    /* Text */
+    --text: #f5f5f7;
+    --text-muted: #a4a4b0;
+    --text-dim: #6e6e7a;
+
+    /* Aurora palette */
+    --aurora-violet: #7c3aed;
+    --aurora-cyan: #06b6d4;
+    --aurora-magenta: #ec4899;
+    --aurora-amber: #f59e0b;
+
+    /* Accent */
+    --accent: #a78bfa;
+    --accent-hot: #c4b5fd;
+    --accent-glow: rgba(167, 139, 250, 0.45);
+
+    /* Type */
+    --font-he: 'Heebo', 'Assistant', system-ui, -apple-system, sans-serif;
+    --font-en: 'Inter', system-ui, -apple-system, sans-serif;
+    --font-mono: 'JetBrains Mono', 'SF Mono', Menlo, monospace;
+
+    /* Radii */
+    --r-sm: 10px;
+    --r-md: 14px;
+    --r-lg: 20px;
+    --r-xl: 28px;
+    --r-pill: 999px;
+
+    /* Easings */
+    --ease: cubic-bezier(0.2, 0.7, 0.2, 1);
+    --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-ul li::before {
-    content: '>';
-    position: absolute;
-    left: 0;
-    color: var(--primary-light);
-    font-weight: 600;
+html[data-lang="he"] body {
+    font-family: var(--font-he);
 }
 
-.container {
-    max-width: 1100px;
-    margin: 0 auto;
-    padding: 0 24px;
+html[data-lang="en"] body {
+    font-family: var(--font-en);
 }
 
-/* ── Navigation ─────────────────────────────────────────── */
+body {
+    font-size: 16px;
+    line-height: 1.6;
+    font-feature-settings: "ss01", "cv01";
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    overflow-x: hidden;
+    min-height: 100vh;
+}
 
-.nav {
+/* ── Language visibility (no flicker, CSS only) ─────────────────── */
+html[data-lang="he"] .en {
+    display: none !important;
+}
+
+html[data-lang="en"] .he {
+    display: none !important;
+}
+
+/* ── Aurora background ──────────────────────────────────────────── */
+.aurora {
     position: fixed;
+    inset: 0;
+    z-index: -1;
+    overflow: hidden;
+    pointer-events: none;
+}
+
+.aurora-blob {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(120px);
+    opacity: 0.55;
+    will-change: transform;
+}
+
+.blob-violet {
+    width: 720px;
+    height: 720px;
+    background: radial-gradient(circle, var(--aurora-violet) 0%, transparent 70%);
+    top: -200px;
+    left: -180px;
+    animation: drift1 28s var(--ease) infinite alternate;
+}
+
+.blob-cyan {
+    width: 640px;
+    height: 640px;
+    background: radial-gradient(circle, var(--aurora-cyan) 0%, transparent 70%);
+    bottom: -200px;
+    right: -160px;
+    animation: drift2 34s var(--ease) infinite alternate;
+}
+
+.blob-magenta {
+    width: 540px;
+    height: 540px;
+    background: radial-gradient(circle, var(--aurora-magenta) 0%, transparent 70%);
+    top: 38%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    opacity: 0.35;
+    animation: drift3 24s var(--ease) infinite alternate;
+}
+
+.aurora-grain {
+    position: absolute;
+    inset: 0;
+    background-image:
+        radial-gradient(circle at 1px 1px, rgba(255, 255, 255, 0.04) 1px, transparent 0);
+    background-size: 3px 3px;
+    opacity: 0.5;
+    mix-blend-mode: overlay;
+}
+
+@keyframes drift1 {
+    from {
+        transform: translate(0, 0) scale(1);
+    }
+
+    to {
+        transform: translate(180px, 80px) scale(1.15);
+    }
+}
+
+@keyframes drift2 {
+    from {
+        transform: translate(0, 0) scale(1);
+    }
+
+    to {
+        transform: translate(-160px, -100px) scale(1.1);
+    }
+}
+
+@keyframes drift3 {
+    from {
+        transform: translate(-50%, -50%) scale(1);
+    }
+
+    to {
+        transform: translate(-30%, -65%) scale(1.25);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+
+    .aurora-blob,
+    .hero-badge-dot,
+    .hero-accent {
+        animation: none !important;
+        transition: none !important;
+    }
+}
+
+/* ── Layout primitives ──────────────────────────────────────────── */
+.container {
+    width: 100%;
+    max-width: 1180px;
+    margin: 0 auto;
+    padding: 0 28px;
+}
+
+.container-narrow {
+    max-width: 820px;
+}
+
+.section {
+    padding: 96px 0;
+    position: relative;
+}
+
+@media (max-width: 720px) {
+    .section {
+        padding: 64px 0;
+    }
+
+    .container {
+        padding: 0 20px;
+    }
+}
+
+/* ── NAV ────────────────────────────────────────────────────────── */
+.nav {
+    position: sticky;
     top: 0;
-    left: 0;
-    right: 0;
     z-index: 100;
-    height: var(--nav-height);
-    transition: background 0.3s, backdrop-filter 0.3s;
+    transition: background 0.3s, backdrop-filter 0.3s, border-color 0.3s;
+    border-bottom: 1px solid transparent;
 }
 
 .nav.scrolled {
-    background: rgba(10, 10, 15, 0.85);
-    backdrop-filter: blur(16px);
-    border-bottom: 1px solid var(--border);
+    background: rgba(7, 7, 13, 0.7);
+    backdrop-filter: blur(18px) saturate(1.4);
+    -webkit-backdrop-filter: blur(18px) saturate(1.4);
+    border-bottom-color: var(--border);
 }
 
 .nav-inner {
-    max-width: 1100px;
+    max-width: 1180px;
     margin: 0 auto;
-    padding: 0 24px;
-    height: 100%;
+    padding: 18px 28px;
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    gap: 24px;
 }
 
 .nav-logo {
-    display: flex;
+    display: inline-flex;
     align-items: center;
-    gap: 8px;
-    font-size: 1.15rem;
+    gap: 10px;
+    font-family: var(--font-en);
     font-weight: 700;
+    font-size: 1.05rem;
+    letter-spacing: -0.01em;
     color: var(--text);
-    letter-spacing: -0.04em;
-    text-decoration: none;
-    white-space: nowrap;
-    line-height: 1;
-}
-
-.nav-logo span {
-    background: var(--gradient);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
 }
 
 .nav-logo-img {
-    width: 26px;
-    height: 26px;
-    flex-shrink: 0;
-    transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
-}
-
-.nav-logo:hover .nav-logo-img {
-    transform: rotate(-12deg) scale(1.15);
-}
-
-.nav-logo:hover {
-    color: var(--text);
+    width: 28px;
+    height: 28px;
 }
 
 .nav-links {
     display: flex;
+    gap: 28px;
+    margin-inline-start: auto;
     align-items: center;
-    gap: 32px;
 }
 
 .nav-links a {
     color: var(--text-muted);
-    font-size: 0.9rem;
+    font-size: 0.92rem;
     font-weight: 500;
     transition: color 0.2s;
+    position: relative;
 }
 
 .nav-links a:hover {
     color: var(--text);
 }
 
-.nav-btn {
-    background: var(--surface);
+.nav-links a::after {
+    content: "";
+    position: absolute;
+    bottom: -6px;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: var(--accent);
+    transform: scaleX(0);
+    transition: transform 0.25s var(--ease);
+    transform-origin: center;
+}
+
+.nav-links a:hover::after {
+    transform: scaleX(1);
+}
+
+.nav-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+}
+
+/* ── Lang toggle pill ──────────────────────────────────────────── */
+.lang-toggle {
+    display: inline-flex;
+    align-items: center;
+}
+
+.lang-toggle-track {
+    position: relative;
+    display: inline-flex;
+    background: var(--glass);
     border: 1px solid var(--border);
-    padding: 8px 16px;
-    border-radius: var(--radius-sm);
-    color: var(--text) !important;
+    border-radius: var(--r-pill);
+    padding: 3px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    transition: border-color 0.2s;
+}
+
+.lang-toggle-track:hover {
+    border-color: var(--border-bright);
+}
+
+.lang-toggle-pill {
+    position: absolute;
+    top: 3px;
+    bottom: 3px;
+    width: calc(50% - 3px);
+    background: linear-gradient(135deg, var(--accent), var(--aurora-magenta));
+    border-radius: var(--r-pill);
+    transition: transform 0.3s var(--ease-out);
+    box-shadow: 0 2px 12px var(--accent-glow);
+}
+
+/* HE option is first in DOM. RTL: HE is on the right (initial pill on right). LTR: HE is on the left. */
+html[dir="rtl"][data-lang="he"] .lang-toggle-pill {
+    transform: translateX(0);
+    inset-inline-start: 3px;
+}
+
+html[dir="rtl"][data-lang="en"] .lang-toggle-pill {
+    transform: translateX(-100%);
+    inset-inline-start: 3px;
+}
+
+html[dir="ltr"][data-lang="he"] .lang-toggle-pill {
+    transform: translateX(0);
+    left: 3px;
+}
+
+html[dir="ltr"][data-lang="en"] .lang-toggle-pill {
+    transform: translateX(100%);
+    left: 3px;
+}
+
+.lang-toggle-opt {
+    position: relative;
+    z-index: 1;
+    padding: 5px 14px;
+    font-family: var(--font-en);
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    transition: color 0.2s;
+    line-height: 1;
+}
+
+html[data-lang="he"] .lang-toggle-opt[data-lang-set="he"],
+html[data-lang="en"] .lang-toggle-opt[data-lang-set="en"] {
+    color: white;
+}
+
+/* ── Nav button (GitHub) ──────────────────────────────────────── */
+.nav-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 9px 16px;
+    background: var(--glass-strong);
+    border: 1px solid var(--border);
+    border-radius: var(--r-pill);
     font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    transition: border-color 0.2s, transform 0.2s, background 0.2s;
 }
 
 .nav-btn:hover {
-    background: var(--surface-hover);
-    color: var(--text) !important;
+    border-color: var(--border-bright);
+    background: rgba(255, 255, 255, 0.09);
+    transform: translateY(-1px);
 }
 
 .nav-toggle {
     display: none;
     flex-direction: column;
     gap: 5px;
-    background: none;
-    border: none;
-    cursor: pointer;
-    padding: 4px;
+    padding: 8px;
 }
 
 .nav-toggle span {
-    display: block;
     width: 22px;
     height: 2px;
     background: var(--text);
-    transition: transform 0.3s, opacity 0.3s;
+    border-radius: 2px;
+    transition: transform 0.25s, opacity 0.25s;
 }
 
 .nav-toggle.open span:nth-child(1) {
@@ -206,107 +445,315 @@ ul li::before {
     transform: translateY(-7px) rotate(-45deg);
 }
 
-/* ── Hero ────────────────────────────────────────────────── */
+@media (max-width: 880px) {
+    .nav-toggle {
+        display: flex;
+    }
 
+    .nav-links {
+        position: fixed;
+        top: 70px;
+        left: 0;
+        right: 0;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0;
+        background: rgba(7, 7, 13, 0.92);
+        backdrop-filter: blur(20px);
+        -webkit-backdrop-filter: blur(20px);
+        border-bottom: 1px solid var(--border);
+        padding: 24px 28px;
+        margin: 0;
+        transform: translateY(-110%);
+        transition: transform 0.3s var(--ease-out);
+    }
+
+    .nav-links.open {
+        transform: translateY(0);
+    }
+
+    .nav-links a {
+        padding: 14px 0;
+        font-size: 1.05rem;
+        border-bottom: 1px solid var(--border);
+    }
+
+    .nav-links a::after {
+        display: none;
+    }
+
+    .nav-btn span {
+        display: none;
+    }
+}
+
+/* ── HERO ───────────────────────────────────────────────────────── */
 .hero {
-    padding: calc(var(--nav-height) + 80px) 0 100px;
-    text-align: center;
+    padding: 120px 0 80px;
+    text-align: start;
+    position: relative;
+    overflow: hidden;
+}
+
+@media (max-width: 720px) {
+    .hero {
+        padding: 80px 0 56px;
+    }
+}
+
+.hero-inner {
+    max-width: 980px;
 }
 
 .hero-badge {
-    display: inline-block;
-    font-size: 0.8rem;
-    font-weight: 500;
-    color: var(--text-muted);
-    background: var(--gradient-subtle);
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 7px 16px;
+    background: var(--glass);
     border: 1px solid var(--border);
-    padding: 6px 16px;
-    border-radius: 100px;
+    border-radius: var(--r-pill);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    font-size: 0.82rem;
+    color: var(--text-muted);
+    letter-spacing: 0.01em;
     margin-bottom: 32px;
 }
 
-.hero h1 {
-    font-size: clamp(2.5rem, 6vw, 4rem);
-    font-weight: 700;
-    line-height: 1.1;
-    letter-spacing: -0.03em;
-    margin-bottom: 24px;
+.hero-badge-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--accent);
+    box-shadow: 0 0 14px var(--accent-glow);
+    animation: pulse 2.4s ease-in-out infinite;
 }
 
+@keyframes pulse {
 
+    0%,
+    100% {
+        opacity: 1;
+        transform: scale(1);
+    }
 
-.gradient-text {
-    background: var(--gradient);
+    50% {
+        opacity: 0.5;
+        transform: scale(1.3);
+    }
+}
+
+.hero-title {
+    font-size: clamp(2.6rem, 7.5vw, 5.6rem);
+    line-height: 1.02;
+    letter-spacing: -0.035em;
+    font-weight: 800;
+    margin: 0 0 28px;
+    color: var(--text);
+}
+
+html[data-lang="he"] .hero-title {
+    font-weight: 900;
+    letter-spacing: -0.025em;
+    line-height: 1.05;
+}
+
+.hero-accent {
+    background: linear-gradient(110deg, var(--accent) 0%, var(--aurora-magenta) 50%, var(--aurora-cyan) 100%);
+    background-size: 200% 100%;
     -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
     background-clip: text;
+    color: transparent;
+    animation: gradient-shift 8s ease infinite;
+    display: inline-block;
+}
+
+@keyframes gradient-shift {
+
+    0%,
+    100% {
+        background-position: 0% 50%;
+    }
+
+    50% {
+        background-position: 100% 50%;
+    }
 }
 
 .hero-sub {
-    max-width: 600px;
-    margin: 0 auto 40px;
-    font-size: 1.1rem;
+    font-size: clamp(1.05rem, 1.8vw, 1.28rem);
     color: var(--text-muted);
-    line-height: 1.7;
+    line-height: 1.55;
+    max-width: 620px;
+    margin: 0 0 40px;
 }
 
 .hero-actions {
     display: flex;
-    gap: 16px;
-    justify-content: center;
+    gap: 14px;
     flex-wrap: wrap;
+    margin-bottom: 64px;
 }
 
+/* ── Buttons ───────────────────────────────────────────────────── */
 .btn {
     display: inline-flex;
     align-items: center;
-    padding: 12px 28px;
-    border-radius: var(--radius-sm);
-    font-size: 0.95rem;
+    justify-content: center;
+    gap: 8px;
+    padding: 14px 26px;
+    border-radius: var(--r-pill);
+    font-size: 0.98rem;
     font-weight: 600;
-    transition: all 0.2s;
+    transition: transform 0.2s, box-shadow 0.3s, background 0.2s, border-color 0.2s;
     cursor: pointer;
+    border: 1px solid transparent;
+}
+
+.btn-sm {
+    padding: 10px 18px;
+    font-size: 0.88rem;
 }
 
 .btn-primary {
-    background: var(--primary);
-    color: #fff;
+    background: linear-gradient(135deg, var(--accent) 0%, var(--aurora-magenta) 100%);
+    color: white;
+    box-shadow:
+        0 4px 24px rgba(167, 139, 250, 0.3),
+        inset 0 1px 0 rgba(255, 255, 255, 0.2);
 }
 
 .btn-primary:hover {
-    background: var(--primary-dark);
-    color: #fff;
-    transform: translateY(-1px);
+    transform: translateY(-2px);
+    box-shadow:
+        0 8px 32px rgba(167, 139, 250, 0.5),
+        inset 0 1px 0 rgba(255, 255, 255, 0.25);
 }
 
-.btn-secondary {
-    background: var(--surface);
+.btn-ghost {
+    background: var(--glass);
+    border-color: var(--border);
+    color: var(--text);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+}
+
+.btn-ghost:hover {
+    background: var(--glass-strong);
+    border-color: var(--border-bright);
+    transform: translateY(-2px);
+}
+
+/* ── Hero stats ────────────────────────────────────────────────── */
+.hero-stats {
+    display: flex;
+    gap: 56px;
+    flex-wrap: wrap;
+    padding-top: 32px;
+    border-top: 1px solid var(--border);
+    max-width: 620px;
+}
+
+.hero-stat-num {
+    font-family: var(--font-en);
+    font-size: 2.2rem;
+    font-weight: 800;
+    letter-spacing: -0.03em;
+    background: linear-gradient(135deg, var(--text) 0%, var(--text-muted) 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    line-height: 1;
+    margin-bottom: 4px;
+}
+
+.hero-stat-label {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+/* ── Section heads ─────────────────────────────────────────────── */
+.section-head {
+    text-align: start;
+    margin-bottom: 56px;
+    max-width: 720px;
+}
+
+.section-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    padding: 5px 12px;
+    background: var(--glass);
     border: 1px solid var(--border);
+    border-radius: var(--r-pill);
+    font-family: var(--font-en);
+    font-size: 0.74rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--accent);
+    margin-bottom: 16px;
+}
+
+html[data-lang="he"] .section-eyebrow {
+    font-family: var(--font-he);
+    font-weight: 700;
+    text-transform: none;
+    letter-spacing: 0.04em;
+}
+
+.section-title {
+    font-size: clamp(2rem, 4.5vw, 3.2rem);
+    line-height: 1.05;
+    letter-spacing: -0.025em;
+    font-weight: 800;
+    margin: 0 0 16px;
     color: var(--text);
 }
 
-.btn-secondary:hover {
-    background: var(--surface-hover);
-    color: var(--text);
-    transform: translateY(-1px);
+.section-title-sm {
+    font-size: clamp(1.4rem, 2.4vw, 1.8rem);
+    margin-bottom: 24px;
 }
 
-/* ── Carousel ─────────────────────────────────────────────── */
+html[data-lang="he"] .section-title {
+    font-weight: 900;
+    line-height: 1.1;
+}
 
+.section-sub {
+    font-size: 1.08rem;
+    color: var(--text-muted);
+    line-height: 1.55;
+    margin: 0;
+    max-width: 620px;
+}
+
+/* ── CAROUSEL ──────────────────────────────────────────────────── */
 .carousel {
-    position: relative;
-    max-width: 1000px;
-    margin: 0 auto;
     outline: none;
 }
 
-.carousel-viewport {
+.carousel-frame {
     position: relative;
-    border-radius: var(--radius-lg);
-    overflow: hidden;
+    background: var(--glass);
     border: 1px solid var(--border);
-    background: var(--surface);
-    aspect-ratio: 16 / 9.2;
+    border-radius: var(--r-xl);
+    backdrop-filter: blur(28px) saturate(1.4);
+    -webkit-backdrop-filter: blur(28px) saturate(1.4);
+    padding: 18px;
+    box-shadow:
+        0 30px 80px -20px rgba(0, 0, 0, 0.6),
+        inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.carousel-viewport {
+    border-radius: var(--r-md);
+    overflow: hidden;
+    aspect-ratio: 16 / 9.5;
+    background: rgba(0, 0, 0, 0.3);
+    position: relative;
 }
 
 .carousel-track {
@@ -319,7 +766,7 @@ ul li::before {
     position: absolute;
     inset: 0;
     opacity: 0;
-    transition: opacity 0.5s ease;
+    transition: opacity 0.6s var(--ease-out);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -330,605 +777,825 @@ ul li::before {
     z-index: 1;
 }
 
-.carousel-img {
-    width: 100%;
-    height: 100%;
-}
-
-.carousel-img img {
+.carousel-slide img {
     width: 100%;
     height: 100%;
     object-fit: cover;
-    object-position: top left;
-    display: block;
+    object-position: top center;
 }
 
-.carousel-img-mobile {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: var(--bg);
-}
-
-.carousel-img-mobile img {
+.carousel-slide-mobile img {
     width: auto;
-    height: 100%;
-    max-width: 45%;
+    max-height: 100%;
     object-fit: contain;
-    object-position: center;
-    border-radius: 12px;
-    box-shadow: 0 8px 40px rgba(0, 0, 0, 0.5);
 }
 
-/* Nav buttons */
 .carousel-btn {
     position: absolute;
     top: 50%;
-    transform: translateY(-80%);
-    z-index: 5;
+    transform: translateY(-50%);
     width: 44px;
     height: 44px;
-    border: 1px solid var(--border);
     border-radius: 50%;
-    background: rgba(10, 10, 15, 0.7);
-    backdrop-filter: blur(8px);
+    background: rgba(7, 7, 13, 0.7);
+    border: 1px solid var(--border-bright);
     color: var(--text);
-    cursor: pointer;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
     display: flex;
     align-items: center;
     justify-content: center;
-    transition: background 0.2s, border-color 0.2s;
-}
-
-.carousel-btn:hover {
-    background: rgba(99, 102, 241, 0.2);
-    border-color: var(--primary);
+    z-index: 5;
+    transition: background 0.2s, transform 0.2s, box-shadow 0.3s;
 }
 
 .carousel-btn svg {
-    width: 20px;
-    height: 20px;
+    width: 22px;
+    height: 22px;
+}
+
+.carousel-btn:hover {
+    background: rgba(7, 7, 13, 0.9);
+    box-shadow: 0 0 24px var(--accent-glow);
+    transform: translateY(-50%) scale(1.05);
 }
 
 .carousel-prev {
-    left: -56px;
+    inset-inline-start: 28px;
 }
 
 .carousel-next {
-    right: -56px;
+    inset-inline-end: 28px;
 }
 
-/* Info bar */
+html[dir="rtl"] .carousel-prev svg,
+html[dir="rtl"] .carousel-next svg {
+    transform: scaleX(-1);
+}
+
+.carousel-meta {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 24px;
+    padding: 28px 8px 4px;
+    flex-wrap: wrap;
+}
+
 .carousel-info {
-    text-align: center;
-    padding: 20px 16px 8px;
+    flex: 1;
+    min-width: 240px;
 }
 
 .carousel-label {
     font-size: 1.15rem;
-    font-weight: 600;
+    font-weight: 700;
+    color: var(--text);
     margin-bottom: 6px;
+    letter-spacing: -0.01em;
 }
 
 .carousel-desc {
     color: var(--text-muted);
-    font-size: 0.9rem;
+    font-size: 0.95rem;
     line-height: 1.5;
-    max-width: 600px;
-    margin: 0 auto;
 }
 
-/* Dots */
 .carousel-dots {
     display: flex;
-    justify-content: center;
-    gap: 10px;
-    padding: 16px 0 4px;
+    gap: 8px;
 }
 
 .carousel-dot {
-    width: 10px;
-    height: 10px;
+    width: 8px;
+    height: 8px;
     border-radius: 50%;
-    border: 1px solid var(--border);
-    background: transparent;
-    cursor: pointer;
-    transition: all 0.3s;
+    background: var(--border-bright);
+    transition: width 0.25s, background 0.25s;
     padding: 0;
 }
 
+.carousel-dot:hover {
+    background: var(--text-muted);
+}
+
 .carousel-dot.active {
-    background: var(--primary);
-    border-color: var(--primary);
-    box-shadow: 0 0 8px rgba(99, 102, 241, 0.4);
+    width: 28px;
+    border-radius: var(--r-pill);
+    background: linear-gradient(90deg, var(--accent), var(--aurora-magenta));
+    box-shadow: 0 0 12px var(--accent-glow);
 }
 
-.carousel-dot:hover:not(.active) {
-    border-color: var(--primary-light);
-    background: rgba(99, 102, 241, 0.2);
-}
-
-/* ── Sections ────────────────────────────────────────────── */
-
-.section {
-    padding: 20px 0 100px;
-}
-
-.section-alt {
-    background: var(--bg-alt);
-}
-
-.section-title {
-    font-size: clamp(1.75rem, 4vw, 2.5rem);
-    font-weight: 700;
-    text-align: center;
-    letter-spacing: -0.02em;
-    margin-bottom: 12px;
-}
-
-.section-sub {
-    text-align: center;
-    color: var(--text-muted);
-    font-size: 1.05rem;
-    max-width: 550px;
-    margin: 0 auto 60px;
-}
-
-/* ── Features ────────────────────────────────────────────── */
-
+/* ── FEATURES GRID ─────────────────────────────────────────────── */
 .features-grid {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 24px;
-    margin-bottom: 48px;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 18px;
 }
 
 .feature-card {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
+    position: relative;
     padding: 32px 28px;
-    transition: border-color 0.3s, transform 0.2s;
+    background: var(--glass);
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+    backdrop-filter: blur(24px) saturate(1.3);
+    -webkit-backdrop-filter: blur(24px) saturate(1.3);
+    transition: transform 0.3s var(--ease), border-color 0.3s, background 0.3s;
+    overflow: hidden;
+}
+
+.feature-card::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(420px circle at 50% 0%, rgba(167, 139, 250, 0.14), transparent 50%);
+    opacity: 0;
+    transition: opacity 0.4s;
+    pointer-events: none;
 }
 
 .feature-card:hover {
-    border-color: var(--primary);
-    transform: translateY(-2px);
+    transform: translateY(-4px);
+    border-color: var(--border-bright);
+    background: var(--glass-strong);
+}
+
+.feature-card:hover::before {
+    opacity: 1;
 }
 
 .feature-icon {
-    width: 44px;
-    height: 44px;
-    background: var(--gradient-subtle);
-    border-radius: var(--radius-sm);
+    width: 48px;
+    height: 48px;
+    border-radius: var(--r-md);
+    background: linear-gradient(135deg, rgba(167, 139, 250, 0.15), rgba(236, 72, 153, 0.1));
+    border: 1px solid rgba(167, 139, 250, 0.25);
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-bottom: 20px;
+    color: var(--accent-hot);
+    margin-bottom: 22px;
 }
 
 .feature-icon svg {
-    width: 22px;
-    height: 22px;
-    color: var(--primary-light);
+    width: 24px;
+    height: 24px;
 }
 
-.feature-card h3 {
-    font-size: 1.1rem;
-    font-weight: 600;
-    margin-bottom: 8px;
+.feature-title {
+    font-size: 1.15rem;
+    font-weight: 700;
+    margin: 0 0 10px;
+    color: var(--text);
     letter-spacing: -0.01em;
 }
 
-.feature-card p {
+.feature-text {
     color: var(--text-muted);
-    font-size: 0.9rem;
-    line-height: 1.6;
-}
-
-/* Feature highlight */
-
-.feature-highlight {
-    background: var(--gradient-subtle);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-lg);
-    padding: 48px;
-    display: flex;
-    gap: 48px;
-    align-items: center;
-}
-
-.feature-highlight-content {
-    flex: 1;
-}
-
-.feature-highlight h3 {
-    font-size: 1.4rem;
-    font-weight: 700;
-    margin-bottom: 12px;
-}
-
-.feature-highlight p {
-    color: var(--text-muted);
+    line-height: 1.55;
+    margin: 0;
     font-size: 0.95rem;
-    line-height: 1.7;
 }
 
-.resource-modes {
+.feature-tags {
     display: flex;
-    gap: 20px;
-    flex-shrink: 0;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 18px;
 }
 
-.resource-mode {
-    text-align: center;
-    padding: 20px 16px;
-    background: var(--surface);
+.tag {
+    font-family: var(--font-en);
+    font-size: 0.72rem;
+    padding: 3px 9px;
+    border-radius: var(--r-pill);
+    background: rgba(255, 255, 255, 0.05);
     border: 1px solid var(--border);
-    border-radius: var(--radius);
-    min-width: 110px;
+    color: var(--text-muted);
 }
 
-.resource-mode-icon {
-    font-size: 1.8rem;
-    margin-bottom: 8px;
+/* ── SECURITY ──────────────────────────────────────────────────── */
+.security-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 18px;
 }
 
-.resource-mode-label {
+.security-card-wide {
+    grid-column: 1 / -1;
+}
+
+.security-card {
+    padding: 32px;
+    background: var(--glass);
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+    backdrop-filter: blur(24px) saturate(1.3);
+    -webkit-backdrop-filter: blur(24px) saturate(1.3);
+    transition: border-color 0.3s, background 0.3s;
+}
+
+.security-card:hover {
+    border-color: var(--border-bright);
+    background: var(--glass-strong);
+}
+
+.security-card h4 {
+    font-size: 1.1rem;
+    font-weight: 700;
+    margin: 0 0 10px;
+    color: var(--text);
+}
+
+.security-card p {
+    color: var(--text-muted);
+    line-height: 1.55;
+    margin: 0;
+    font-size: 0.93rem;
+}
+
+.security-icon {
+    font-size: 1.6rem;
+    color: var(--accent-hot);
+    margin-bottom: 14px;
+    line-height: 1;
+}
+
+.security-flow {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
+    margin-bottom: 24px;
+}
+
+.flow-step {
+    flex: 1;
+    min-width: 140px;
+    padding: 16px 18px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    text-align: start;
+}
+
+.flow-key {
+    font-size: 0.95rem;
     font-weight: 600;
-    font-size: 0.9rem;
+    color: var(--text);
     margin-bottom: 4px;
 }
 
-.resource-mode-desc {
-    font-size: 0.75rem;
+.flow-meta {
+    font-family: var(--font-mono);
+    font-size: 0.74rem;
+    color: var(--accent-hot);
+    letter-spacing: 0.02em;
+}
+
+.flow-arrow {
+    color: var(--text-dim);
+    font-size: 1.4rem;
+    line-height: 1;
+}
+
+html[dir="rtl"] .flow-arrow {
+    transform: scaleX(-1);
+}
+
+.security-explainer {
+    color: var(--text-muted);
+    line-height: 1.6;
+    margin: 0;
+    font-size: 0.95rem;
+}
+
+@media (max-width: 720px) {
+    .security-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .security-flow {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .flow-arrow {
+        transform: rotate(90deg);
+        align-self: center;
+    }
+
+    html[dir="rtl"] .flow-arrow {
+        transform: rotate(90deg) scaleX(-1);
+    }
+}
+
+/* ── HEBREW NATIVE SECTION ─────────────────────────────────────── */
+.section-hebrew {
+    padding: 56px 0;
+}
+
+.hebrew-card {
+    display: grid;
+    grid-template-columns: 1.2fr 1fr;
+    gap: 48px;
+    align-items: center;
+    padding: 56px;
+    background: linear-gradient(135deg, rgba(167, 139, 250, 0.08), rgba(6, 182, 212, 0.05));
+    border: 1px solid rgba(167, 139, 250, 0.18);
+    border-radius: var(--r-xl);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    box-shadow: 0 30px 80px -20px rgba(124, 58, 237, 0.15);
+}
+
+@media (max-width: 880px) {
+    .hebrew-card {
+        grid-template-columns: 1fr;
+        padding: 40px 28px;
+        gap: 32px;
+    }
+}
+
+.hebrew-list {
+    margin-top: 28px;
+}
+
+.hebrew-list li {
+    padding: 12px 0;
+    border-top: 1px solid var(--border);
+    color: var(--text-muted);
+    font-size: 0.97rem;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.hebrew-list li::before {
+    content: "✦";
+    color: var(--accent);
+    font-size: 0.9rem;
+}
+
+.hebrew-mock {
+    padding: 32px;
+    background: rgba(7, 7, 13, 0.6);
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+}
+
+.hebrew-mock-num {
+    font-family: var(--font-en);
+    font-size: 3rem;
+    font-weight: 800;
+    letter-spacing: -0.03em;
+    background: linear-gradient(135deg, var(--accent), var(--aurora-magenta));
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    line-height: 1;
+    margin-bottom: 8px;
+    direction: ltr;
+}
+
+.hebrew-mock-label {
+    color: var(--text-muted);
+    font-size: 0.92rem;
+    margin-bottom: 20px;
+}
+
+.hebrew-mock-bar {
+    height: 8px;
+    background: var(--border);
+    border-radius: var(--r-pill);
+    overflow: hidden;
+    margin-bottom: 12px;
+}
+
+.hebrew-mock-bar-fill {
+    width: 73%;
+    height: 100%;
+    background: linear-gradient(90deg, var(--accent), var(--aurora-magenta));
+    border-radius: var(--r-pill);
+    box-shadow: 0 0 12px var(--accent-glow);
+}
+
+.hebrew-mock-meta {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.85rem;
     color: var(--text-muted);
 }
 
-/* ── Credits ──────────────────────────────────────────────── */
+.hebrew-mock-trend {
+    color: var(--accent-hot);
+    font-weight: 600;
+}
 
-.credits-card {
-    max-width: 640px;
-    margin: 0 auto;
-    background: var(--surface);
+/* ── RUNS ANYWHERE ─────────────────────────────────────────────── */
+.runs-card {
+    padding: 48px;
+    background: var(--glass);
     border: 1px solid var(--border);
-    border-radius: var(--radius-lg);
-    padding: 48px 40px;
+    border-radius: var(--r-xl);
+    backdrop-filter: blur(24px) saturate(1.3);
+    -webkit-backdrop-filter: blur(24px) saturate(1.3);
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    gap: 48px;
+}
+
+.runs-text h3 {
+    font-size: clamp(1.6rem, 3vw, 2.2rem);
+    font-weight: 800;
+    margin: 0 0 14px;
+    letter-spacing: -0.02em;
+    color: var(--text);
+}
+
+html[data-lang="he"] .runs-text h3 {
+    font-weight: 900;
+}
+
+.runs-text p {
+    color: var(--text-muted);
+    line-height: 1.6;
+    margin: 0;
+    font-size: 1rem;
+}
+
+.runs-text strong {
+    color: var(--text);
+    font-weight: 600;
+}
+
+.runs-modes {
+    display: flex;
+    gap: 16px;
+}
+
+.runs-mode {
     text-align: center;
+    padding: 22px 26px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    min-width: 140px;
+}
+
+.runs-mode-icon {
+    font-size: 1.6rem;
+    color: var(--accent-hot);
+    margin-bottom: 8px;
+}
+
+.runs-mode-label {
+    font-family: var(--font-mono);
+    font-weight: 600;
+    color: var(--text);
+    margin-bottom: 4px;
+    font-size: 0.95rem;
+}
+
+.runs-mode-desc {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+}
+
+@media (max-width: 720px) {
+    .runs-card {
+        grid-template-columns: 1fr;
+        padding: 32px 24px;
+        gap: 28px;
+    }
+
+    .runs-modes {
+        justify-content: stretch;
+    }
+
+    .runs-mode {
+        flex: 1;
+        min-width: 0;
+    }
+}
+
+/* ── CREDITS ───────────────────────────────────────────────────── */
+.credits-card {
+    text-align: center;
+    padding: 56px 40px;
+    background: var(--glass);
+    border: 1px solid var(--border);
+    border-radius: var(--r-xl);
+    backdrop-filter: blur(24px) saturate(1.3);
+    -webkit-backdrop-filter: blur(24px) saturate(1.3);
+    max-width: 760px;
+    margin: 0 auto;
 }
 
 .credits-icon {
-    width: 56px;
-    height: 56px;
-    background: var(--gradient-subtle);
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin: 0 auto 20px;
-}
-
-.credits-icon svg {
-    width: 26px;
-    height: 26px;
-    color: #ec4899;
+    font-size: 2.2rem;
+    color: var(--aurora-magenta);
+    margin-bottom: 16px;
+    text-shadow: 0 0 28px rgba(236, 72, 153, 0.5);
 }
 
 .credits-card h3 {
+    font-family: var(--font-mono);
     font-size: 1.3rem;
-    font-weight: 700;
-    margin-bottom: 14px;
-    letter-spacing: -0.01em;
+    font-weight: 600;
+    margin: 0 0 14px;
+    color: var(--text);
 }
 
 .credits-card p {
     color: var(--text-muted);
-    font-size: 0.95rem;
-    line-height: 1.7;
-    margin-bottom: 24px;
+    line-height: 1.65;
+    margin: 0 0 28px;
 }
 
-.credits-card a:not(.btn) {
-    color: var(--primary-light);
-    font-weight: 600;
+.credits-card a {
+    color: var(--accent-hot);
+    text-decoration: underline;
+    text-decoration-color: rgba(167, 139, 250, 0.4);
+    text-underline-offset: 3px;
 }
 
-.credits-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
+.credits-card a:hover {
+    text-decoration-color: var(--accent-hot);
 }
 
-/* ── Installation ─────────────────────────────────────────── */
+/* ── INSTALLATION ──────────────────────────────────────────────── */
+.install-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 18px;
+}
 
-.install-steps {
-    max-width: 720px;
-    margin: 0 auto;
-    display: flex;
-    flex-direction: column;
-    gap: 36px;
+@media (max-width: 720px) {
+    .install-grid {
+        grid-template-columns: 1fr;
+    }
 }
 
 .install-step {
-    display: flex;
-    gap: 24px;
-}
-
-.step-number {
-    width: 40px;
-    height: 40px;
-    background: var(--gradient-subtle);
+    padding: 32px;
+    background: var(--glass);
     border: 1px solid var(--border);
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-weight: 700;
-    font-size: 1rem;
-    color: var(--primary-light);
-    flex-shrink: 0;
-}
-
-.step-content {
-    flex: 1;
-}
-
-.step-content h3 {
-    font-size: 1.05rem;
-    font-weight: 600;
-    margin-bottom: 8px;
-}
-
-.step-content p {
-    color: var(--text-muted);
-    font-size: 0.9rem;
-    margin-bottom: 12px;
-}
-
-.step-content ul {
-    margin-bottom: 8px;
-}
-
-.step-content li {
-    color: var(--text-muted);
-    font-size: 0.9rem;
-    margin-bottom: 4px;
-}
-
-.code-block {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    overflow-x: auto;
-    margin-top: 8px;
-}
-
-.code-block pre {
-    padding: 16px 20px;
-    margin: 0;
-}
-
-.code-block code {
-    background: none;
-    padding: 0;
-    font-size: 0.82rem;
-    color: var(--text-muted);
-    line-height: 1.7;
-}
-
-/* ── Configuration ────────────────────────────────────────── */
-
-.config-grid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 24px;
-}
-
-.config-card {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 28px;
-}
-
-.config-card h3 {
-    font-size: 1.05rem;
-    font-weight: 600;
-    margin-bottom: 10px;
-}
-
-.config-card p {
-    color: var(--text-muted);
-    font-size: 0.9rem;
-    line-height: 1.6;
-    margin-bottom: 10px;
-}
-
-.config-card ul {
-    margin-top: 8px;
-}
-
-.config-card li {
-    color: var(--text-muted);
-    font-size: 0.9rem;
-    margin-bottom: 4px;
-}
-
-.config-table {
-    width: 100%;
-    border-collapse: collapse;
-    margin-top: 12px;
-    font-size: 0.85rem;
-}
-
-.config-table th {
-    text-align: left;
-    padding: 8px 12px;
-    border-bottom: 1px solid var(--border);
-    color: var(--text-muted);
-    font-weight: 500;
-    font-size: 0.8rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-}
-
-.config-table td {
-    padding: 8px 12px;
-    border-bottom: 1px solid var(--border);
-    color: var(--text-muted);
-}
-
-.config-table tr:last-child td {
-    border-bottom: none;
-}
-
-/* ── Tech ─────────────────────────────────────────────────── */
-
-.tech-section {
-    padding: 60px 0;
-}
-
-.tech-grid {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 12px;
-    margin-top: 32px;
-}
-
-.tech-item {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    padding: 10px 20px;
-    border-radius: 100px;
-    font-size: 0.85rem;
-    font-weight: 500;
-    color: var(--text-muted);
-}
-
-/* ── FAQ ──────────────────────────────────────────────────── */
-
-.faq-list {
-    max-width: 760px;
-    margin: 0 auto;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-}
-
-.faq-item {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    overflow: hidden;
+    border-radius: var(--r-lg);
+    backdrop-filter: blur(24px) saturate(1.3);
+    -webkit-backdrop-filter: blur(24px) saturate(1.3);
     transition: border-color 0.3s;
 }
 
-.faq-item[open] {
-    border-color: var(--primary);
+.install-step:hover {
+    border-color: var(--border-bright);
 }
 
-.faq-question {
-    padding: 20px 24px;
-    font-size: 1rem;
+.step-num {
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
     font-weight: 600;
-    cursor: pointer;
+    color: var(--accent);
+    margin-bottom: 12px;
+    letter-spacing: 0.05em;
+}
+
+.install-step h3 {
+    font-size: 1.15rem;
+    font-weight: 700;
+    margin: 0 0 16px;
+    color: var(--text);
+    letter-spacing: -0.01em;
+}
+
+.install-step ul {
+    color: var(--text-muted);
+    font-size: 0.95rem;
+}
+
+.install-step li {
+    padding: 6px 0;
+    position: relative;
+    padding-inline-start: 18px;
+}
+
+.install-step li::before {
+    content: "›";
+    position: absolute;
+    inset-inline-start: 0;
+    color: var(--accent);
+    font-weight: 600;
+}
+
+.install-step pre,
+.faq-pre {
+    background: rgba(0, 0, 0, 0.4);
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    padding: 16px 18px;
+    overflow-x: auto;
+    margin: 0;
+    direction: ltr;
+    text-align: left;
+}
+
+.install-step code,
+.faq-pre code {
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    color: var(--text);
+    line-height: 1.6;
+    white-space: pre;
+    background: none;
+    padding: 0;
+}
+
+.install-step p,
+.install-foot {
+    color: var(--text-muted);
+    font-size: 0.92rem;
+    margin: 14px 0 0;
+}
+
+.install-foot code {
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    background: rgba(255, 255, 255, 0.06);
+    padding: 2px 8px;
+    border-radius: 6px;
+    color: var(--accent-hot);
+    direction: ltr;
+    display: inline-block;
+}
+
+/* ── TECH PILLS ────────────────────────────────────────────────── */
+.tech-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.tech-pill {
+    font-family: var(--font-en);
+    font-size: 0.84rem;
+    font-weight: 500;
+    padding: 8px 16px;
+    background: var(--glass);
+    border: 1px solid var(--border);
+    border-radius: var(--r-pill);
+    color: var(--text-muted);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    transition: color 0.2s, border-color 0.2s;
+}
+
+.tech-pill:hover {
+    color: var(--text);
+    border-color: var(--border-bright);
+}
+
+/* ── FAQ ───────────────────────────────────────────────────────── */
+.faq-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.faq-item {
+    padding: 0;
+    background: var(--glass);
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    transition: border-color 0.2s, background 0.2s;
+}
+
+.faq-item:hover {
+    border-color: var(--border-bright);
+}
+
+.faq-item[open] {
+    background: var(--glass-strong);
+    border-color: rgba(167, 139, 250, 0.25);
+}
+
+.faq-item summary {
     list-style: none;
+    cursor: pointer;
+    padding: 22px 28px;
+    font-weight: 600;
+    font-size: 1.02rem;
+    color: var(--text);
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 16px;
-    transition: color 0.2s;
-    user-select: none;
 }
 
-.faq-question::-webkit-details-marker {
+.faq-item summary::-webkit-details-marker {
     display: none;
 }
 
-.faq-question::after {
-    content: '+';
-    font-size: 1.3rem;
-    font-weight: 400;
+.faq-item summary::after {
+    content: "+";
+    font-size: 1.4rem;
+    font-weight: 300;
+    color: var(--accent);
+    transition: transform 0.25s;
+    line-height: 1;
+}
+
+.faq-item[open] summary::after {
+    transform: rotate(45deg);
+}
+
+.faq-body {
+    padding: 0 28px 24px;
     color: var(--text-muted);
-    flex-shrink: 0;
-    transition: transform 0.3s;
+    line-height: 1.65;
+    font-size: 0.97rem;
 }
 
-.faq-item[open] .faq-question::after {
-    content: '\2212';
-    color: var(--primary-light);
+.faq-body p {
+    margin: 0 0 12px;
 }
 
-.faq-question:hover {
-    color: var(--primary-light);
-}
-
-.faq-answer {
-    padding: 0 24px 20px;
-}
-
-.faq-answer p {
-    color: var(--text-muted);
-    font-size: 0.9rem;
-    line-height: 1.7;
-    margin-bottom: 10px;
-}
-
-.faq-answer p:last-child {
+.faq-body p:last-child {
     margin-bottom: 0;
 }
 
-.faq-answer a {
-    color: var(--primary-light);
-    font-weight: 600;
+.faq-body a {
+    color: var(--accent-hot);
+    text-decoration: underline;
+    text-decoration-color: rgba(167, 139, 250, 0.4);
+    text-underline-offset: 3px;
 }
 
-/* ── Footer ───────────────────────────────────────────────── */
+.faq-body strong {
+    color: var(--text);
+}
 
+.faq-pre {
+    margin: 14px 0;
+    font-size: 0.78rem;
+}
+
+/* ── FOOTER ────────────────────────────────────────────────────── */
 .footer {
+    padding: 64px 0 40px;
     border-top: 1px solid var(--border);
-    padding: 48px 0 32px;
+    margin-top: 64px;
 }
 
 .footer-inner {
     display: flex;
     justify-content: space-between;
-    align-items: flex-start;
+    align-items: center;
+    gap: 32px;
+    flex-wrap: wrap;
     margin-bottom: 32px;
 }
 
-.footer-logo {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 1.1rem;
-    font-weight: 700;
-    margin-bottom: 8px;
-    letter-spacing: -0.04em;
+.footer-brand {
+    max-width: 360px;
 }
 
-.footer-logo span {
-    background: var(--gradient);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+.footer-logo {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    font-family: var(--font-en);
+    font-weight: 700;
+    margin-bottom: 6px;
+    color: var(--text);
+}
+
+.footer-logo img {
+    width: 24px;
+    height: 24px;
 }
 
 .footer-brand p {
     color: var(--text-muted);
-    font-size: 0.85rem;
+    font-size: 0.9rem;
+    margin: 0;
 }
 
 .footer-links {
     display: flex;
-    gap: 24px;
+    gap: 28px;
+    flex-wrap: wrap;
 }
 
 .footer-links a {
     color: var(--text-muted);
-    font-size: 0.85rem;
-    font-weight: 500;
+    font-size: 0.9rem;
+    transition: color 0.2s;
 }
 
 .footer-links a:hover {
@@ -936,134 +1603,39 @@ ul li::before {
 }
 
 .footer-bottom {
+    text-align: center;
+    color: var(--text-dim);
+    font-size: 0.82rem;
+    padding-top: 24px;
     border-top: 1px solid var(--border);
-    padding-top: 20px;
 }
 
 .footer-bottom p {
-    color: var(--text-muted);
-    font-size: 0.8rem;
-    text-align: center;
+    margin: 0;
 }
 
-/* ── Responsive ───────────────────────────────────────────── */
-
-@media (max-width: 900px) {
-    .features-grid {
-        grid-template-columns: repeat(2, 1fr);
-    }
-
-    .feature-highlight {
-        flex-direction: column;
-        padding: 32px;
-    }
-
-    .resource-modes {
-        width: 100%;
-        justify-content: center;
-    }
-
-    .config-grid {
-        grid-template-columns: 1fr;
-    }
-
-    .carousel-prev {
-        left: 8px;
-    }
-
-    .carousel-next {
-        right: 8px;
-    }
-
-    .carousel-btn {
-        width: 36px;
-        height: 36px;
-        background: rgba(10, 10, 15, 0.85);
-    }
-
-    .carousel-btn svg {
-        width: 16px;
-        height: 16px;
-    }
+/* ── Selection ─────────────────────────────────────────────────── */
+::selection {
+    background: rgba(167, 139, 250, 0.4);
+    color: white;
 }
 
-@media (max-width: 640px) {
-    .nav-links {
-        position: fixed;
-        top: var(--nav-height);
-        left: 0;
-        right: 0;
-        background: rgba(10, 10, 15, 0.95);
-        backdrop-filter: blur(16px);
-        flex-direction: column;
-        padding: 24px;
-        gap: 20px;
-        border-bottom: 1px solid var(--border);
-        transform: translateY(-100%);
-        opacity: 0;
-        pointer-events: none;
-        transition: transform 0.3s, opacity 0.3s;
-    }
+/* ── Scrollbar ─────────────────────────────────────────────────── */
+::-webkit-scrollbar {
+    width: 12px;
+    height: 12px;
+}
 
-    .nav-links.open {
-        transform: translateY(0);
-        opacity: 1;
-        pointer-events: all;
-    }
+::-webkit-scrollbar-track {
+    background: var(--bg);
+}
 
-    .nav-toggle {
-        display: flex;
-    }
+::-webkit-scrollbar-thumb {
+    background: var(--border-bright);
+    border-radius: var(--r-pill);
+    border: 3px solid var(--bg);
+}
 
-    .features-grid {
-        grid-template-columns: 1fr;
-    }
-
-    .hero {
-        padding: calc(var(--nav-height) + 48px) 0 64px;
-    }
-
-    .hero-sub {
-        font-size: 1rem;
-    }
-
-    .section {
-        padding: 90px 0 64px;
-    }
-
-    .resource-modes {
-        flex-direction: column;
-        align-items: center;
-    }
-
-    .resource-mode {
-        min-width: 160px;
-    }
-
-    .install-step {
-        flex-direction: column;
-        gap: 12px;
-    }
-
-    .footer-inner {
-        flex-direction: column;
-        gap: 24px;
-    }
-
-    .carousel-prev {
-        left: 4px;
-    }
-
-    .carousel-next {
-        right: 4px;
-    }
-
-    .carousel-btn {
-        width: 32px;
-        height: 32px;
-    }
-
-    .carousel-img-mobile img {
-        max-width: 60%;
-    }
+::-webkit-scrollbar-thumb:hover {
+    background: var(--text-dim);
 }


### PR DESCRIPTION
## Summary
Full rewrite of the GitHub Pages site (**nudlers.com**) — new aesthetic, Hebrew-first, latest features incorporated.

### What changed
- **Aesthetic:** animated aurora mesh background (three drifting violet/cyan/magenta blobs), frosted-glass cards, gradient hero accent that shifts hue, glow-on-hover, mono accents on crypto/security details.
- **Hebrew is now the default.** Page loads `lang=\"he\" dir=\"rtl\"` with Heebo display type. A pill toggle in the nav flips to English (`lang=\"en\" dir=\"ltr\"`, Inter). Choice persists in localStorage; first-paint reads localStorage *before* CSS loads, so there's zero language flicker.
- **i18n implementation:** both languages live side-by-side via paired `.he` / `.en` spans. Visibility is pure CSS (`html[data-lang=\"he\"] .en { display: none }`), so the toggle doesn't have to swap any DOM text — just one attribute on `<html>`.
- **New content blocks** (the old site missed these):
  - **Security flow** — visual chain showing `Passphrase → scrypt → Wrapping Key → AES-256-GCM → Master Key (memory only) → Encrypted credentials`.
  - **Native 2FA** — calls out OneZero + Hapoalim OTP support added in recent PRs.
  - **Hebrew/RTL native** — a meta moment: the marketing page itself demoing the in-app i18n work.
  - **Zero-telemetry** card.
- **All FAQ rewritten in natural Hebrew** with English equivalents preserved.

### Verified locally
- ✅ Headless Chromium render at 1440×900 and 390×844 (mobile)
- ✅ HE↔EN toggle round-trips, `dir` and `lang` switch correctly, language persists
- ✅ Carousel arrows mirror direction in RTL
- ✅ Code blocks force `dir=\"ltr\"` so commands render correctly inside Hebrew context
- ✅ No console errors on load
- ✅ \`prefers-reduced-motion\` honored — aurora drift, hero badge pulse, gradient shift all stop

### Test plan
- [ ] Visit nudlers.com after merge, confirm Hebrew loads first
- [ ] Toggle EN/עב, scroll through every section in both
- [ ] Test mobile (Safari iOS, Chrome Android)
- [ ] Confirm fonts load (Heebo + Inter from Google Fonts)
- [ ] Sanity-check the encryption flow text with the actual implementation

### Out of scope
- The screenshots in \`docs/assets/\` (summary.png, transactions.png, etc.) are unchanged. They show English UI — when the in-app Hebrew screenshots are ready, swap them in via a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)