### PR TITLE
fix(vault): wait for WhatsApp readiness before sending unlock notification

### DIFF
--- a/app/tests/vault-unlock-notify.test.ts
+++ b/app/tests/vault-unlock-notify.test.ts
@@ -8,6 +8,32 @@ vi.mock('../pages/api/db', () => ({
 vi.mock('../utils/whatsapp.js', () => ({
     sendWhatsAppMessage: vi.fn(),
 }));
+vi.mock('../utils/whatsapp-client.js', () => {
+    // A minimal EventEmitter stand-in for the wwjs client. Tests can fire
+    // 'ready' / 'auth_failure' on it to drive the readiness wait.
+    const listeners = new Map<string, Function[]>();
+    const client = {
+        once: vi.fn((evt: string, cb: Function) => {
+            if (!listeners.has(evt)) listeners.set(evt, []);
+            listeners.get(evt)!.push(cb);
+        }),
+        off: vi.fn((evt: string, cb: Function) => {
+            const arr = listeners.get(evt);
+            if (!arr) return;
+            const idx = arr.indexOf(cb);
+            if (idx >= 0) arr.splice(idx, 1);
+        }),
+        emit: (evt: string, ...args: unknown[]) => {
+            const arr = listeners.get(evt) || [];
+            // Drain — `once` semantics mean we only fire each callback at most once.
+            const snapshot = arr.slice();
+            arr.length = 0;
+            snapshot.forEach((cb) => cb(...args));
+        },
+        _reset: () => listeners.clear(),
+    };
+    return { getOrCreateClient: vi.fn(() => client), __mockClient: client };
+});
 vi.mock('../utils/logger.js', () => ({
     default: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
 }));
@@ -15,7 +41,11 @@ vi.mock('../utils/logger.js', () => ({
 import { unlockVaultWithPassphrase, _resetUnlockNotificationFlagForTests } from '../utils/vault-utils';
 import { getDB } from '../pages/api/db';
 import { sendWhatsAppMessage } from '../utils/whatsapp.js';
+import * as whatsappClientModule from '../utils/whatsapp-client.js';
 import VaultStore from '../pages/api/utils/VaultStore';
+
+// Pull the EventEmitter-shaped stand-in we built in the mock factory.
+const mockWaClient = (whatsappClientModule as unknown as { __mockClient: { emit: (evt: string, ...args: unknown[]) => void; _reset: () => void } }).__mockClient;
 
 const PASSPHRASE = 'test-passphrase-123';
 
@@ -76,10 +106,16 @@ describe('unlockVaultWithPassphrase — WhatsApp notify on unlock', () => {
         vi.clearAllMocks();
         VaultStore.clear();
         _resetUnlockNotificationFlagForTests();
+        mockWaClient._reset();
+        // Default for the existing tests: WhatsApp is already up and running,
+        // so waitForWhatsAppReady() short-circuits and tests don't need to
+        // emit any event to make the send happen.
+        (global as unknown as { whatsappStatus?: string }).whatsappStatus = 'READY';
     });
 
     afterEach(() => {
         vi.restoreAllMocks();
+        delete (global as unknown as { whatsappStatus?: string }).whatsappStatus;
     });
 
     it('does NOT send a WhatsApp message when the setting is disabled', async () => {
@@ -144,6 +180,52 @@ describe('unlockVaultWithPassphrase — WhatsApp notify on unlock', () => {
         await flushMicrotasks();
 
         expect(result.success).toBe(true);
+        expect(VaultStore.isLocked()).toBe(false);
+    });
+
+    it('waits for the ready event when WhatsApp is still INITIALIZING at unlock time, then sends', async () => {
+        // Reproduce the actual production race: user just restarted the app
+        // and unlocked while the WhatsApp client is still loading its session.
+        (global as unknown as { whatsappStatus?: string }).whatsappStatus = 'INITIALIZING';
+
+        const { wrappedStr, saltHex } = buildWrappedMasterKey();
+        mockSettingsRows({ wrappedStr, saltHex, notifyEnabled: true, recipients: '972501234567' });
+        (sendWhatsAppMessage as any).mockResolvedValue({ success: true, sent: 1 });
+
+        const result = await unlockVaultWithPassphrase(PASSPHRASE);
+        await flushMicrotasks();
+
+        expect(result.success).toBe(true);
+        // Send must NOT have happened yet — we're still waiting on `ready`.
+        expect(sendWhatsAppMessage).not.toHaveBeenCalled();
+
+        // Simulate WhatsApp finishing its session restore.
+        mockWaClient.emit('ready');
+        // Two flushes: one for `ready` resolving the wait, one for the awaited send.
+        await flushMicrotasks();
+        await flushMicrotasks();
+
+        expect(sendWhatsAppMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('drops the notification (without crashing) if WhatsApp auth fails while we wait', async () => {
+        (global as unknown as { whatsappStatus?: string }).whatsappStatus = 'INITIALIZING';
+
+        const { wrappedStr, saltHex } = buildWrappedMasterKey();
+        mockSettingsRows({ wrappedStr, saltHex, notifyEnabled: true, recipients: '972501234567' });
+
+        const result = await unlockVaultWithPassphrase(PASSPHRASE);
+        await flushMicrotasks();
+
+        expect(result.success).toBe(true);
+        expect(sendWhatsAppMessage).not.toHaveBeenCalled();
+
+        mockWaClient.emit('auth_failure', 'session expired');
+        await flushMicrotasks();
+        await flushMicrotasks();
+
+        // Still no send — auth failure aborted the wait, and unlock survived.
+        expect(sendWhatsAppMessage).not.toHaveBeenCalled();
         expect(VaultStore.isLocked()).toBe(false);
     });
 

--- a/app/utils/vault-utils.js
+++ b/app/utils/vault-utils.js
@@ -154,10 +154,63 @@ async function maybeNotifyUnlock() {
     });
     const body = `🔓 Nudlers — הכספת נפתחה\n${time}\n(אחרי הפעלה מחדש של האפליקציה)`;
 
+    // At server startup the WhatsApp client is usually still INITIALIZING
+    // (loading its persisted session). Sending immediately would throw
+    // "client not ready", get swallowed by our fire-and-forget catch, and
+    // burn the one-shot flag for nothing. Wait for it to actually be usable
+    // before attempting the send.
+    try {
+        await waitForWhatsAppReady(90_000);
+    } catch (err) {
+        logger.warn({ err: err.message }, 'WhatsApp not ready in time; skipping unlock notification');
+        return;
+    }
+
     // Dynamic import so a missing/broken WhatsApp module never breaks unlock.
     const { sendWhatsAppMessage } = await import('./whatsapp.js');
     await sendWhatsAppMessage({ to: recipients, body });
     logger.info('Unlock notification sent');
+}
+
+/**
+ * Resolve when the WhatsApp client is READY (or AUTHENTICATED) and able to
+ * send. Resolves immediately if it already is. Otherwise listens for the
+ * `ready` event on the underlying singleton, with a hard timeout. Rejects on
+ * `auth_failure` or timeout — both are signals to drop the notification rather
+ * than spin forever.
+ */
+async function waitForWhatsAppReady(timeoutMs) {
+    const globalAny = global;
+    const status = globalAny.whatsappStatus;
+    if (status === 'READY' || status === 'AUTHENTICATED') return;
+
+    // Pull a client reference (creates one if the singleton hasn't booted yet,
+    // which can happen if instrumentation.ts skipped initialization).
+    const { getOrCreateClient } = await import('./whatsapp-client.js');
+    const client = getOrCreateClient();
+
+    return new Promise((resolve, reject) => {
+        const cleanup = () => {
+            clearTimeout(timer);
+            client.off?.('ready', onReady);
+            client.off?.('authenticated', onAuthed);
+            client.off?.('auth_failure', onFail);
+        };
+        const onReady = () => { cleanup(); resolve(); };
+        const onAuthed = () => { cleanup(); resolve(); };
+        const onFail = (msg) => {
+            cleanup();
+            reject(new Error(`WhatsApp authentication failure: ${msg}`));
+        };
+        const timer = setTimeout(() => {
+            cleanup();
+            reject(new Error(`WhatsApp client did not become ready within ${timeoutMs}ms`));
+        }, timeoutMs);
+
+        client.once('ready', onReady);
+        client.once('authenticated', onAuthed);
+        client.once('auth_failure', onFail);
+    });
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #97. The unlock-notify feature didn't actually fire in production for the most common case — the user reported it directly.

### The bug
At server startup `whatsapp-web.js` takes ~10–30s to restore its persisted session. During that window the cached \`whatsappStatus\` is \`INITIALIZING\`. If you unlocked the vault inside that window:
1. \`maybeNotifyUnlock\` ran
2. \`sendWhatsAppMessage\` threw \"WhatsApp client not ready\"
3. The fire-and-forget \`.catch\` swallowed it as a warning
4. The one-shot \`unlockNotificationFired\` flag was already burned
5. Even after WhatsApp came online, no message was ever sent

So the feature only worked if you happened to unlock *after* WhatsApp had finished authenticating — which on a NAS is rarely the case, since unlocking is usually the first thing you do after a restart.

### The fix
New \`waitForWhatsAppReady(90s)\` helper, called before \`sendWhatsAppMessage\`. It:
- Short-circuits when status is already \`READY\` or \`AUTHENTICATED\` (steady-state path is unchanged)
- Otherwise listens for the underlying client's \`ready\` / \`authenticated\` event with a 90-second hard timeout
- Aborts early on \`auth_failure\` to avoid spinning when re-auth is required
- On timeout, drops the notification cleanly — preferable to hanging the promise forever

The one-shot flag still fires correctly: it's consumed at the moment of unlock, so even if the wait times out we don't double-fire on a subsequent unlock in the same session.

### Tests
Two new cases that exercise the actual race that bit you:
- \`waits for the ready event when WhatsApp is still INITIALIZING at unlock time, then sends\` — sets status to \`INITIALIZING\` before unlock, asserts no send happens until \`mockClient.emit('ready')\`, then asserts the send fires
- \`drops the notification (without crashing) if WhatsApp auth fails while we wait\` — asserts \`auth_failure\` aborts the wait without breaking the unlock

8/8 in \`vault-unlock-notify.test.ts\`. 73/73 across vault + WhatsApp suites. No regressions.

### Test plan
- [x] Unit tests cover the race + auth-failure paths
- [ ] Manual: enable the setting, save, restart the app, unlock immediately. Confirm the WhatsApp message arrives within ~10s of WhatsApp finishing its session restore (instead of never)

🤖 Generated with [Claude Code](https://claude.com/claude-code)