### PR TITLE
feat(whatsapp): Baileys transport behind a feature-flagged router

### DIFF
--- a/app/components/SettingsModal.tsx
+++ b/app/components/SettingsModal.tsx
@@ -73,6 +73,7 @@ interface Settings {
   whatsapp_to: string;
   whatsapp_summary_mode: 'calendar' | 'cycle';
   whatsapp_notify_on_restart: boolean;
+  whatsapp_transport: 'web' | 'baileys';
 
   telegram_enabled: boolean;
   telegram_bot_token: string;
@@ -241,6 +242,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
     whatsapp_to: '',
     whatsapp_summary_mode: 'calendar',
     whatsapp_notify_on_restart: false,
+    whatsapp_transport: 'web',
 
     telegram_enabled: false,
     telegram_bot_token: '',
@@ -296,6 +298,31 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
 
     return () => clearInterval(interval);
   }, [open, whatsappStatus.status]);
+
+  const handleTransportChange = async (next: 'web' | 'baileys') => {
+    if (next === settings.whatsapp_transport) return;
+    const ok = window.confirm(
+      t('settings:whatsapp.transportConfirm')
+    );
+    if (!ok) return;
+    try {
+      const res = await fetch('/api/whatsapp/transport', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ transport: next }),
+      });
+      if (!res.ok) {
+        logger.error('Transport switch failed', new Error(`HTTP ${res.status}`));
+        return;
+      }
+      setSettings({ ...settings, whatsapp_transport: next });
+      // The status indicator should refresh — reset it so the next poll
+      // picks up the new transport's state.
+      setWhatsappStatus({ status: 'INITIALIZING', qr: null });
+    } catch (e) {
+      logger.error('Transport switch network error', e as Error);
+    }
+  };
 
   const handleWhatsAppAction = async (action: 'connect' | 'restart' | 'disconnect' | 'renewQr') => {
     try {
@@ -378,6 +405,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
           whatsapp_to: (data.settings.whatsapp_to || '').replace(/"/g, ''),
           whatsapp_summary_mode: (data.settings.whatsapp_summary_mode || 'calendar').replace(/"/g, '') as 'calendar' | 'cycle',
           whatsapp_notify_on_restart: parseBool(data.settings.whatsapp_notify_on_restart),
+          whatsapp_transport: ((data.settings.whatsapp_transport || '').replace(/^"(.*)"$/, '$1') === 'baileys' ? 'baileys' : 'web') as 'web' | 'baileys',
 
           telegram_enabled: parseBool(data.settings.telegram_enabled),
           telegram_bot_token: (data.settings.telegram_bot_token || '').replace(/^"(.*)"$/, '$1'),
@@ -1014,6 +1042,25 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
                   </Box>
                 )}
               </Box>
+
+              {/* Transport selector — pick legacy whatsapp-web.js or Baileys */}
+              <SettingRow>
+                <Box>
+                  <Typography variant="body1">{t('settings:whatsapp.transportLabel')}</Typography>
+                  <Typography variant="caption" sx={{ color: theme.palette.text.secondary }}>
+                    {t('settings:whatsapp.transportDesc')}
+                  </Typography>
+                </Box>
+                <StyledSelect
+                  value={settings.whatsapp_transport}
+                  onChange={(e) => handleTransportChange(e.target.value as 'web' | 'baileys')}
+                  size="small"
+                  sx={{ width: 220 }}
+                >
+                  <MenuItem value="web">{t('settings:whatsapp.transportWeb')}</MenuItem>
+                  <MenuItem value="baileys">{t('settings:whatsapp.transportBaileys')}</MenuItem>
+                </StyledSelect>
+              </SettingRow>
 
               {/* QR Code Section */}
               {whatsappStatus.status === 'QR_READY' && whatsappStatus.qr && (

--- a/app/i18n/locales/en/settings.json
+++ b/app/i18n/locales/en/settings.json
@@ -66,6 +66,11 @@
   },
   "whatsapp": {
     "section": "WhatsApp Daily Summary",
+    "transportLabel": "Implementation",
+    "transportDesc": "WhatsApp Web (legacy) uses Chromium/Puppeteer. Baileys talks the WhatsApp Multi-Device protocol directly — no browser, lower memory, faster startup. Switching transports requires a one-time fresh QR scan.",
+    "transportWeb": "WhatsApp Web (legacy)",
+    "transportBaileys": "Baileys (recommended)",
+    "transportConfirm": "Switching transports will require a fresh QR scan. Your current session will be reset. Continue?",
     "scanInstruction": "Scan this QR code with WhatsApp (Settings > Linked Devices)",
     "generateQr": "Generate QR Code",
     "generateQrHelp": "Click to start WhatsApp connection and generate QR code",

--- a/app/i18n/locales/he/settings.json
+++ b/app/i18n/locales/he/settings.json
@@ -66,6 +66,11 @@
   },
   "whatsapp": {
     "section": "סיכום יומי בוואטסאפ",
+    "transportLabel": "מימוש",
+    "transportDesc": "WhatsApp Web (ישן) משתמש בכרומיום/Puppeteer. Baileys מדבר ישירות עם פרוטוקול הריבוי-מכשירים של וואטסאפ — בלי דפדפן, פחות זיכרון, הפעלה מהירה יותר. החלפת מימוש מחייבת סריקת QR חד-פעמית.",
+    "transportWeb": "WhatsApp Web (ישן)",
+    "transportBaileys": "Baileys (מומלץ)",
+    "transportConfirm": "החלפת המימוש תדרוש סריקת QR חדשה והסשן הנוכחי יתאפס. להמשיך?",
     "scanInstruction": "סרקו את קוד ה-QR בוואטסאפ (הגדרות > מכשירים מקושרים)",
     "generateQr": "יצירת קוד QR",
     "generateQrHelp": "לחצו כדי להתחיל חיבור לוואטסאפ וליצור קוד QR",

--- a/app/instrumentation.ts
+++ b/app/instrumentation.ts
@@ -89,14 +89,16 @@ export async function register() {
       logger.error({ error: err.message, stack: err.stack }, '[startup] Failed to run migrations');
     }
 
-    // Initialize WhatsApp Client (Singleton)
+    // Initialize WhatsApp Client through the transport router. The router
+    // reads the `whatsapp_transport` setting and lazy-imports either the
+    // legacy whatsapp-web.js client or the Baileys client. Importing the
+    // chosen module triggers its auto-restore-from-disk side effect.
     try {
-      logger.info('[startup] Initializing WhatsApp Client singleton');
-      const { getClient } = await import('./utils/whatsapp-client.js');
-      getClient(); // Triggers initialization
+      logger.info('[startup] Initializing WhatsApp transport router');
+      await import('./utils/whatsapp-transport.js');
     } catch (error: unknown) {
       const err = error as Error;
-      logger.error({ error: err.message }, '[startup] Failed to initialize WhatsApp Client');
+      logger.error({ error: err.message }, '[startup] Failed to initialize WhatsApp transport router');
     }
 
 

--- a/app/migrations/015_whatsapp_transport.sql
+++ b/app/migrations/015_whatsapp_transport.sql
@@ -1,0 +1,20 @@
+-- Migration: WhatsApp transport selector.
+-- Two implementations now exist:
+--   'web'     — whatsapp-web.js (Puppeteer/Chromium, the legacy default).
+--   'baileys' — @whiskeysockets/baileys (direct WebSocket protocol).
+--
+-- We default to 'web' so existing installs upgrade with zero behaviour
+-- change. Switching to 'baileys' requires a one-time fresh QR scan because
+-- the auth state format is different — that's surfaced in the settings UI
+-- with a confirm dialog, not silently.
+--
+-- Idempotent: ON CONFLICT DO NOTHING preserves any value the user already
+-- set by hand or via the settings UI.
+
+INSERT INTO app_settings (key, value, description)
+VALUES (
+    'whatsapp_transport',
+    '"web"'::jsonb,
+    'WhatsApp transport implementation: "web" (whatsapp-web.js, legacy) or "baileys" (recommended — no Chromium, lower memory)'
+)
+ON CONFLICT (key) DO NOTHING;

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -6,7 +6,13 @@ const nextConfig = {
   env: {
     PORT: '6969',
   },
-  serverExternalPackages: ['puppeteer', 'israeli-bank-scrapers', 'bufferutil', 'utf-8-validate'],
+  // Baileys is added as an external because it has optional image-processing
+  // deps (jimp, sharp) that are imported via `import('...').catch(() => {})`
+  // at runtime. Turbopack's static module resolution flags these as missing
+  // at build time even though Baileys handles their absence gracefully. We
+  // only send text, so those deps are never reached. Treating Baileys as
+  // an external also keeps puppeteer/baileys out of the client bundle.
+  serverExternalPackages: ['puppeteer', 'israeli-bank-scrapers', 'bufferutil', 'utf-8-validate', '@whiskeysockets/baileys', 'jimp', 'sharp'],
 };
 
 export default nextConfig;

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -21,6 +21,7 @@
         "@mui/x-date-pickers": "^8.3.1",
         "@simplewebauthn/browser": "^13.2.2",
         "@simplewebauthn/server": "^13.2.2",
+        "@whiskeysockets/baileys": "^7.0.0-rc10",
         "canvas-confetti": "^1.9.4",
         "date-fns": "^4.1.0",
         "dotenv": "^16.5.0",
@@ -380,6 +381,95 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@cacheable/memory": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.8.tgz",
+      "integrity": "sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.4.0",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/memory/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/@cacheable/node-cache": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@cacheable/node-cache/-/node-cache-1.7.6.tgz",
+      "integrity": "sha512-6Omk2SgNnjtxB5f/E6bTIWIt5xhdpx39fGNRQgU9lojvRxU68v+qY+SXXLsp3ZGukqoPjsK21wZ6XABFr/Ge3A==",
+      "license": "MIT",
+      "dependencies": {
+        "cacheable": "^2.3.1",
+        "hookified": "^1.14.0",
+        "keyv": "^5.5.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cacheable/node-cache/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.1.tgz",
+      "integrity": "sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==",
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.5.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/utils/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/@chromatic-com/storybook": {
@@ -1240,6 +1330,21 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
+    "node_modules/@hapi/boom": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@hexagon/base64": {
       "version": "1.1.28",
       "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
@@ -1315,7 +1420,6 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
       "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -2143,6 +2247,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "license": "MIT"
     },
     "node_modules/@levischuck/tiny-cbor": {
       "version": "0.2.11",
@@ -3177,6 +3287,70 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@puppeteer/browsers": {
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
@@ -4099,6 +4273,29 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -4336,6 +4533,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -4362,7 +4565,6 @@
       "version": "22.19.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
       "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -5352,6 +5554,95 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@whiskeysockets/baileys": {
+      "version": "7.0.0-rc10",
+      "resolved": "https://registry.npmjs.org/@whiskeysockets/baileys/-/baileys-7.0.0-rc10.tgz",
+      "integrity": "sha512-tVHZRIE06HlQajHcLEsCa+gnH5z+dAXPjwHsGXDNY9/Y0iqbymQzHLvh4tMH/pi/ea/D617qCQhNkDT2B0tufg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/node-cache": "^1.4.0",
+        "@hapi/boom": "^9.1.3",
+        "async-mutex": "^0.5.0",
+        "libsignal": "git+https://github.com/whiskeysockets/libsignal-node.git",
+        "lru-cache": "^11.1.0",
+        "music-metadata": "^11.12.3",
+        "p-queue": "^9.0.0",
+        "pino": "^9.6",
+        "protobufjs": "^7.5.6",
+        "whatsapp-rust-bridge": "0.5.3",
+        "ws": "^8.13.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "audio-decode": "^2.1.3",
+        "jimp": "^1.6.1",
+        "link-preview-js": "^3.0.0",
+        "sharp": "*"
+      },
+      "peerDependenciesMeta": {
+        "audio-decode": {
+          "optional": true
+        },
+        "jimp": {
+          "optional": true
+        },
+        "link-preview-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@whiskeysockets/baileys/node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@whiskeysockets/baileys/node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/@whiskeysockets/baileys/node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/@whiskeysockets/baileys/node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -5910,6 +6201,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -6395,6 +6695,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cacheable": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.5.tgz",
+      "integrity": "sha512-EQfaKe09tl615iNvq/TBRWTFf1AKJNXYQSsMx0Z3EI0nA+pVsVPS8wJhnRlkbdacKPh1d0qVIhwTc2zsQNFEEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/memory": "^2.0.8",
+        "@cacheable/utils": "^2.4.1",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.10.1"
+      }
+    },
+    "node_modules/cacheable/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/call-bind": {
@@ -7052,6 +7374,12 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/curve25519-js": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/curve25519-js/-/curve25519-js-0.0.4.tgz",
+      "integrity": "sha512-axn2UMEnkhyDUPWOwVKBMVIzSQy2ejH2xRGy1wq81dqRwApXfIzfbE3hIX0ZRFBIihf/KDqK158DLwESu4AK1w==",
+      "license": "MIT"
+    },
     "node_modules/d3-array": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
@@ -7427,7 +7755,6 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -8426,6 +8753,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/events-universal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
@@ -8680,6 +9013,24 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/filesize": {
@@ -9291,6 +9642,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hashery": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -9392,6 +9755,12 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -9543,8 +9912,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -10571,6 +10939,54 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libsignal": {
+      "name": "@whiskeysockets/libsignal-node",
+      "version": "2.0.1",
+      "resolved": "git+ssh://git@github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67",
+      "license": "GPL-3.0",
+      "dependencies": {
+        "curve25519-js": "^0.0.4",
+        "protobufjs": "6.8.8"
+      }
+    },
+    "node_modules/libsignal/node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "license": "MIT"
+    },
+    "node_modules/libsignal/node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/libsignal/node_modules/protobufjs": {
+      "version": "6.8.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
+      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.0",
+        "@types/node": "^10.1.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -10654,6 +11070,12 @@
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -11898,6 +12320,37 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/music-metadata": {
+      "version": "11.12.3",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-11.12.3.tgz",
+      "integrity": "sha512-n6hSTZkuD59qWgHh6IP5dtDlDZQXoxk/bcA85Jywg8Z1iFrlNgl2+GTFgjZyn52W5UgQpV42V4XqrQZZAMbZTQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/Borewit"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://buymeacoffee.com/borewit"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.2",
+        "@tokenizer/token": "^0.3.0",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "file-type": "^21.3.1",
+        "media-typer": "^1.1.0",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.2",
+        "uint8array-extras": "^1.5.0",
+        "win-guid": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/mute-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
@@ -12492,6 +12945,34 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.2.0.tgz",
+      "integrity": "sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -13312,6 +13793,30 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -13452,6 +13957,24 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/qified": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+      "integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/qified/node_modules/hookified": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+      "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
+      "license": "MIT"
     },
     "node_modules/qrcode-terminal": {
       "version": "0.12.0",
@@ -14422,7 +14945,6 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -14466,7 +14988,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -15097,6 +15618,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -15622,6 +16159,24 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/totalist": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -16002,6 +16557,18 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -16025,7 +16592,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -16654,6 +17220,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/whatsapp-rust-bridge": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.5.3.tgz",
+      "integrity": "sha512-Xb3GAgtWQQJ30oI4a4pjM4+YUeli9CMLTwTIewUrb+AJMFElIkiT5uo+j1Zhc+amiV0Jj+LfX76c/EEZirJbGA==",
+      "license": "MIT"
+    },
     "node_modules/whatsapp-web.js": {
       "version": "1.34.5-alpha.3",
       "resolved": "git+ssh://git@github.com/pedroslopez/whatsapp-web.js.git#dd9df4083accf50c2a69d6942a205465f022dc97",
@@ -16805,6 +17377,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/win-guid": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/win-guid/-/win-guid-0.2.1.tgz",
+      "integrity": "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A==",
+      "license": "MIT"
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",

--- a/app/package.json
+++ b/app/package.json
@@ -32,6 +32,7 @@
     "@mui/x-date-pickers": "^8.3.1",
     "@simplewebauthn/browser": "^13.2.2",
     "@simplewebauthn/server": "^13.2.2",
+    "@whiskeysockets/baileys": "^7.0.0-rc10",
     "canvas-confetti": "^1.9.4",
     "date-fns": "^4.1.0",
     "dotenv": "^16.5.0",

--- a/app/pages/api/whatsapp/status.js
+++ b/app/pages/api/whatsapp/status.js
@@ -1,10 +1,13 @@
 
-import { getStatus, restartClient, destroyClient, initializeClient, renewQrCode } from '../../../utils/whatsapp-client.js';
+import { getStatus, restartClient, destroyClient, initializeClient, renewQrCode, getActiveTransport } from '../../../utils/whatsapp-transport.js';
 
 export default async function handler(req, res) {
     if (req.method === 'GET') {
         const status = getStatus();
-        return res.status(200).json(status);
+        // Surface the active transport so the settings UI can show which
+        // implementation is currently driving things ("on Baileys" vs "on
+        // legacy WA Web").
+        return res.status(200).json({ ...status, transport: getActiveTransport() });
     }
 
     if (req.method === 'POST') {

--- a/app/pages/api/whatsapp/transport.js
+++ b/app/pages/api/whatsapp/transport.js
@@ -1,0 +1,64 @@
+import { getDB } from '../db.js';
+import { reloadTransport, getActiveTransport } from '../../../utils/whatsapp-transport.js';
+import logger from '../../../utils/logger.js';
+
+const ALLOWED = new Set(['web', 'baileys']);
+
+/**
+ * POST /api/whatsapp/transport  { transport: 'web' | 'baileys' }
+ *
+ * Persists the transport choice and forces the router to reload. Each
+ * transport has its own auth dir, so flipping requires a fresh QR scan —
+ * we surface that in the response so the UI can show a clear prompt.
+ *
+ * GET returns the current transport.
+ */
+export default async function handler(req, res) {
+    if (req.method === 'GET') {
+        return res.status(200).json({ transport: getActiveTransport() ?? 'web' });
+    }
+
+    if (req.method !== 'POST') {
+        res.setHeader('Allow', ['GET', 'POST']);
+        return res.status(405).json({ error: 'Method not allowed' });
+    }
+
+    const requested = (req.body && req.body.transport) || '';
+    if (!ALLOWED.has(requested)) {
+        return res.status(400).json({ error: `transport must be one of: ${[...ALLOWED].join(', ')}` });
+    }
+
+    const client = await getDB();
+    try {
+        await client.query(
+            `INSERT INTO app_settings (key, value, description)
+             VALUES ('whatsapp_transport', $1::jsonb, 'WhatsApp transport implementation')
+             ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = CURRENT_TIMESTAMP`,
+            [JSON.stringify(requested)]
+        );
+    } catch (err) {
+        logger.error({ err: err.message }, '[transport-api] Failed to persist transport setting');
+        return res.status(500).json({ error: 'Internal Server Error' });
+    } finally {
+        try { client.release(); } catch { /* ignore */ }
+    }
+
+    try {
+        await reloadTransport();
+    } catch (err) {
+        logger.error({ err: err.message }, '[transport-api] reloadTransport failed');
+        // The setting persisted; client just isn't running yet. Surface
+        // the error so the user can manually re-trigger via "Generate QR".
+        return res.status(200).json({
+            transport: requested,
+            warning: `Transport saved but reload failed: ${err.message}`,
+        });
+    }
+
+    return res.status(200).json({
+        transport: requested,
+        // Active transport may differ briefly during the reload race; the
+        // client will see the right value on next status poll.
+        active: getActiveTransport(),
+    });
+}

--- a/app/tests/whatsapp-client-baileys.test.ts
+++ b/app/tests/whatsapp-client-baileys.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+vi.mock('../utils/logger.js', () => ({
+    default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), trace: vi.fn(), child: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), trace: vi.fn() }) },
+}));
+
+// Mock fs so the module's autoRestoreSession() can't accidentally find a
+// real session on disk and trigger initialization on import.
+vi.mock('fs', async () => {
+    const actual = await vi.importActual<typeof import('fs')>('fs');
+    return {
+        ...actual,
+        default: {
+            ...actual,
+            existsSync: vi.fn(() => false),
+            statSync: vi.fn(() => ({ size: 0 })),
+            mkdirSync: vi.fn(),
+            rmSync: vi.fn(),
+        },
+        existsSync: vi.fn(() => false),
+        statSync: vi.fn(() => ({ size: 0 })),
+        mkdirSync: vi.fn(),
+        rmSync: vi.fn(),
+    };
+});
+
+interface MockSock {
+    ev: EventEmitter;
+    sendMessage: ReturnType<typeof vi.fn>;
+    end: ReturnType<typeof vi.fn>;
+    ws: { close: ReturnType<typeof vi.fn> };
+}
+
+let lastMockSock: MockSock | null = null;
+let makeWASocketMock: ReturnType<typeof vi.fn>;
+let saveCredsMock: ReturnType<typeof vi.fn>;
+
+vi.mock('@whiskeysockets/baileys', () => {
+    saveCredsMock = vi.fn().mockResolvedValue(undefined);
+    makeWASocketMock = vi.fn(() => {
+        const sock: MockSock = {
+            ev: new EventEmitter(),
+            sendMessage: vi.fn().mockResolvedValue({ key: { id: 'mocked-msg-id' } }),
+            end: vi.fn(),
+            ws: { close: vi.fn() },
+        };
+        lastMockSock = sock;
+        return sock;
+    });
+    return {
+        default: makeWASocketMock,
+        // Some Baileys exports are namespaced; expose the bits the client
+        // module reaches for via `await import` destructuring.
+        useMultiFileAuthState: vi.fn().mockResolvedValue({
+            state: {},
+            saveCreds: saveCredsMock,
+        }),
+        fetchLatestBaileysVersion: vi.fn().mockResolvedValue({ version: [2, 3000, 0] }),
+        Browsers: {
+            macOS: (name: string) => [name, 'Safari', '1.0'],
+            appropriate: (name: string) => [name, 'Safari', '1.0'],
+        },
+        DisconnectReason: {
+            loggedOut: 401,
+            connectionClosed: 428,
+            connectionLost: 408,
+            badSession: 500,
+            restartRequired: 515,
+        },
+    };
+});
+
+// Reset ALL of the module's globalThis state between tests so each test
+// starts from a clean slate. The module memoizes its singleton on global,
+// which is fine in production but lethal for test isolation.
+function clearBaileysGlobals() {
+    const g = globalThis as unknown as Record<string, unknown>;
+    delete g.baileysSock;
+    delete g.baileysStatus;
+    delete g.baileysQr;
+    delete g.baileysSaveCreds;
+    delete g.baileysEmitter;
+    delete g.baileysAutoRestoreAttempted;
+    delete g.whatsappStatus;
+}
+
+describe('whatsapp-client-baileys', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        clearBaileysGlobals();
+        // Re-import the module fresh each test so autoRestoreSession's
+        // module-load side effect runs against the current mock state.
+        vi.resetModules();
+    });
+
+    afterEach(() => {
+        clearBaileysGlobals();
+    });
+
+    it('reports DISCONNECTED before any init', async () => {
+        const mod = await import('../utils/whatsapp-client-baileys.js');
+        const status = mod.getStatus();
+        expect(status.status).toBe('DISCONNECTED');
+        expect(status.qr).toBeNull();
+    });
+
+    it('initializes a socket and reports INITIALIZING immediately', async () => {
+        const mod = await import('../utils/whatsapp-client-baileys.js');
+        await mod.initializeClient();
+        expect(makeWASocketMock).toHaveBeenCalledTimes(1);
+        const status = mod.getStatus();
+        // Status is INITIALIZING (or QR_READY if a QR fired synchronously).
+        expect(['INITIALIZING', 'QR_READY', 'READY']).toContain(status.status);
+    });
+
+    it('transitions to QR_READY when the socket emits a qr update', async () => {
+        const mod = await import('../utils/whatsapp-client-baileys.js');
+        await mod.initializeClient();
+        lastMockSock!.ev.emit('connection.update', { qr: 'fake-qr-string' });
+        const status = mod.getStatus();
+        expect(status.status).toBe('QR_READY');
+        expect(status.qr).toBe('fake-qr-string');
+    });
+
+    it('transitions to READY when connection.update reports open', async () => {
+        const mod = await import('../utils/whatsapp-client-baileys.js');
+        await mod.initializeClient();
+        lastMockSock!.ev.emit('connection.update', { connection: 'open' });
+        expect(mod.getStatus().status).toBe('READY');
+        expect(mod.getStatus().qr).toBeNull();
+    });
+
+    it('saves creds to disk on creds.update', async () => {
+        const mod = await import('../utils/whatsapp-client-baileys.js');
+        await mod.initializeClient();
+        lastMockSock!.ev.emit('creds.update');
+        // Microtask flush so the async handler runs.
+        await new Promise((r) => setImmediate(r));
+        expect(saveCredsMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT auto-reconnect on a loggedOut close (clears session instead)', async () => {
+        const mod = await import('../utils/whatsapp-client-baileys.js');
+        await mod.initializeClient();
+        expect(makeWASocketMock).toHaveBeenCalledTimes(1);
+
+        lastMockSock!.ev.emit('connection.update', {
+            connection: 'close',
+            lastDisconnect: { error: { output: { statusCode: 401 } } }, // loggedOut
+        });
+
+        // Wait long enough that any (errant) auto-reconnect would have fired.
+        await new Promise((r) => setTimeout(r, 50));
+        // Still only the original socket creation — no reconnect.
+        expect(makeWASocketMock).toHaveBeenCalledTimes(1);
+        expect(mod.getStatus().status).toBe('DISCONNECTED');
+    });
+
+    it('auto-reconnects on a non-loggedOut close after the backoff', async () => {
+        const mod = await import('../utils/whatsapp-client-baileys.js');
+        await mod.initializeClient();
+        expect(makeWASocketMock).toHaveBeenCalledTimes(1);
+
+        lastMockSock!.ev.emit('connection.update', {
+            connection: 'close',
+            lastDisconnect: { error: { output: { statusCode: 428 } } }, // connectionClosed
+        });
+
+        // Backoff is 2_000ms in the production code path. Wait a bit longer
+        // and let the async reconnect (dynamic-import + useMultiFileAuthState
+        // + makeWASocket) settle. We use real timers because the reconnect
+        // chain awaits multiple promises that don't all surface as fake-timer
+        // tasks.
+        await new Promise((r) => setTimeout(r, 2_500));
+
+        expect(makeWASocketMock).toHaveBeenCalledTimes(2);
+    }, 10_000);
+
+    it('sendText projects Baileys response into a unified { id } shape', async () => {
+        const mod = await import('../utils/whatsapp-client-baileys.js');
+        await mod.initializeClient();
+        const result = await mod.sendText({
+            client: lastMockSock,
+            chatId: '972500000000@c.us',
+            body: 'hi',
+        });
+        expect(result).toEqual({ id: 'mocked-msg-id' });
+        expect(lastMockSock!.sendMessage).toHaveBeenCalledWith(
+            '972500000000@c.us',
+            { text: 'hi' }
+        );
+    });
+
+    it('destroyClient tears down the socket and clears state', async () => {
+        const mod = await import('../utils/whatsapp-client-baileys.js');
+        await mod.initializeClient();
+        // Get to READY first so we have something meaningful to tear down.
+        lastMockSock!.ev.emit('connection.update', { connection: 'open' });
+        expect(mod.getStatus().status).toBe('READY');
+
+        await mod.destroyClient();
+        expect(mod.getStatus().status).toBe('DISCONNECTED');
+        expect(mod.getClient()).toBeNull();
+        expect(lastMockSock!.end).toHaveBeenCalled();
+    });
+
+    it('waitForReady resolves immediately if status is already READY', async () => {
+        const mod = await import('../utils/whatsapp-client-baileys.js');
+        await mod.initializeClient();
+        lastMockSock!.ev.emit('connection.update', { connection: 'open' });
+        await expect(mod.waitForReady({ timeoutMs: 100 })).resolves.toBeUndefined();
+    });
+
+    it('waitForReady rejects on auth failure (loggedOut close)', async () => {
+        const mod = await import('../utils/whatsapp-client-baileys.js');
+        await mod.initializeClient();
+
+        const promise = mod.waitForReady({ timeoutMs: 5000 });
+        // Fire the loggedOut close on the next tick so the listener is
+        // already attached.
+        await new Promise((r) => setImmediate(r));
+        lastMockSock!.ev.emit('connection.update', {
+            connection: 'close',
+            lastDisconnect: { error: { output: { statusCode: 401 } } },
+        });
+
+        await expect(promise).rejects.toThrow(/logged out/i);
+    });
+});

--- a/app/tests/whatsapp-status-api.test.ts
+++ b/app/tests/whatsapp-status-api.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import handler from '../pages/api/whatsapp/status.js';
 
-// Mock the whatsapp-client module
-vi.mock('../utils/whatsapp-client.js', () => ({
+// Mock the transport router (the API now goes through it instead of
+// importing whatsapp-client.js directly).
+vi.mock('../utils/whatsapp-transport.js', () => ({
     getStatus: vi.fn().mockReturnValue({
         status: 'DISCONNECTED',
         qr: null,
@@ -12,9 +13,10 @@ vi.mock('../utils/whatsapp-client.js', () => ({
     destroyClient: vi.fn().mockResolvedValue(undefined),
     initializeClient: vi.fn(),
     renewQrCode: vi.fn(),
+    getActiveTransport: vi.fn().mockReturnValue('web'),
 }));
 
-import { getStatus, restartClient, destroyClient, initializeClient, renewQrCode } from '../utils/whatsapp-client.js';
+import { getStatus, restartClient, destroyClient, initializeClient, renewQrCode } from '../utils/whatsapp-transport.js';
 
 // Helper to create mock req/res
 function createMockReqRes(method: string, body?: object) {

--- a/app/tests/whatsapp.test.ts
+++ b/app/tests/whatsapp.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { sendWhatsAppMessage } from '../utils/whatsapp.js';
-import { ensureConnected } from '../utils/whatsapp-client.js';
+import { ensureConnected, sendText } from '../utils/whatsapp-transport.js';
 
-// Mock the modules
-vi.mock('../utils/whatsapp-client.js', () => ({
+// Mock the transport router. The two surfaces we touch from whatsapp.js are
+// ensureConnected (returns the active transport's client) and sendText
+// (transport-uniform wrapper around sendMessage).
+vi.mock('../utils/whatsapp-transport.js', () => ({
     ensureConnected: vi.fn(),
+    sendText: vi.fn(),
 }));
 
 vi.mock('../utils/logger.js', () => ({
@@ -16,14 +19,13 @@ vi.mock('../utils/logger.js', () => ({
 }));
 
 describe('sendWhatsAppMessage', () => {
-    let mockClient: any;
+    let mockClient: object;
 
     beforeEach(() => {
         vi.clearAllMocks();
-        mockClient = {
-            sendMessage: vi.fn().mockResolvedValue({ id: { _serialized: 'msg123' } }),
-        };
-        (ensureConnected as any).mockResolvedValue(mockClient);
+        mockClient = {};
+        (ensureConnected as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(mockClient);
+        (sendText as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'msg123' });
     });
 
     it('should send a message to a single phone number', async () => {
@@ -32,7 +34,7 @@ describe('sendWhatsAppMessage', () => {
             body: 'Hello test',
         });
 
-        expect(mockClient.sendMessage).toHaveBeenCalledWith('972501234567@c.us', 'Hello test');
+        expect(sendText).toHaveBeenCalledWith({ client: mockClient, chatId: '972501234567@c.us', body: 'Hello test' });
         expect(result.success).toBe(true);
         expect(result.sent).toBe(1);
     });
@@ -43,9 +45,9 @@ describe('sendWhatsAppMessage', () => {
             body: 'Hello multiple',
         });
 
-        expect(mockClient.sendMessage).toHaveBeenCalledTimes(2);
-        expect(mockClient.sendMessage).toHaveBeenCalledWith('972501234567@c.us', 'Hello multiple');
-        expect(mockClient.sendMessage).toHaveBeenCalledWith('972507654321@c.us', 'Hello multiple');
+        expect(sendText).toHaveBeenCalledTimes(2);
+        expect(sendText).toHaveBeenCalledWith({ client: mockClient, chatId: '972501234567@c.us', body: 'Hello multiple' });
+        expect(sendText).toHaveBeenCalledWith({ client: mockClient, chatId: '972507654321@c.us', body: 'Hello multiple' });
         expect(result.sent).toBe(2);
     });
 
@@ -55,7 +57,7 @@ describe('sendWhatsAppMessage', () => {
             body: 'Hello group',
         });
 
-        expect(mockClient.sendMessage).toHaveBeenCalledWith('1234567890@g.us', 'Hello group');
+        expect(sendText).toHaveBeenCalledWith({ client: mockClient, chatId: '1234567890@g.us', body: 'Hello group' });
         expect(result.sent).toBe(1);
     });
 
@@ -65,14 +67,14 @@ describe('sendWhatsAppMessage', () => {
             body: 'Hello mix',
         });
 
-        expect(mockClient.sendMessage).toHaveBeenCalledTimes(2);
-        expect(mockClient.sendMessage).toHaveBeenCalledWith('972501234567@c.us', 'Hello mix');
-        expect(mockClient.sendMessage).toHaveBeenCalledWith('1234567890@g.us', 'Hello mix');
+        expect(sendText).toHaveBeenCalledTimes(2);
+        expect(sendText).toHaveBeenCalledWith({ client: mockClient, chatId: '972501234567@c.us', body: 'Hello mix' });
+        expect(sendText).toHaveBeenCalledWith({ client: mockClient, chatId: '1234567890@g.us', body: 'Hello mix' });
         expect(result.sent).toBe(2);
     });
 
     it('should throw error if client cannot be connected', async () => {
-        (ensureConnected as any).mockRejectedValueOnce(
+        (ensureConnected as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
             new Error('WhatsApp client did not become ready within 60000ms')
         );
 
@@ -83,9 +85,11 @@ describe('sendWhatsAppMessage', () => {
     });
 
     it('should continue if one recipient fails but others succeed', async () => {
-        mockClient.sendMessage
-            .mockRejectedValueOnce(new Error('Failed to send'))
-            .mockResolvedValueOnce({ id: { _serialized: 'msg456' } });
+        // Use a deterministic non-transient error so the retry path doesn't
+        // kick in (which would burn 1.5s on the test).
+        (sendText as unknown as ReturnType<typeof vi.fn>)
+            .mockRejectedValueOnce(new Error('chat not found'))
+            .mockResolvedValueOnce({ id: 'msg456' });
 
         const result = await sendWhatsAppMessage({
             to: 'fail, success',
@@ -97,5 +101,22 @@ describe('sendWhatsAppMessage', () => {
         expect(result.total).toBe(2);
         expect(result.results[0].success).toBe(false);
         expect(result.results[1].success).toBe(true);
+    });
+
+    it('retries once on transient transport-death errors then succeeds', async () => {
+        (sendText as unknown as ReturnType<typeof vi.fn>)
+            .mockRejectedValueOnce(new Error('Target frame detached'))
+            .mockResolvedValueOnce({ id: 'msg789' });
+
+        const result = await sendWhatsAppMessage({
+            to: '972501234567',
+            body: 'after-flap',
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.sent).toBe(1);
+        expect(result.results[0].retried).toBe(true);
+        // ensureConnected called twice: once at the top, once at the retry.
+        expect(ensureConnected).toHaveBeenCalledTimes(2);
     });
 });

--- a/app/tests/whatsappStartupNotify.test.ts
+++ b/app/tests/whatsappStartupNotify.test.ts
@@ -1,38 +1,9 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { notifyAppStartedWithLockedVault } from '../utils/whatsappStartupNotify.js';
 
 vi.mock('../utils/logger.js', () => ({
     default: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
 }));
-
-interface MockClient {
-    once: (evt: string, cb: (...args: unknown[]) => void) => void;
-    off: (evt: string, cb: (...args: unknown[]) => void) => void;
-    emit: (evt: string, ...args: unknown[]) => void;
-}
-
-function makeMockClient(): MockClient {
-    const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
-    return {
-        once: (evt, cb) => {
-            const arr = listeners.get(evt) ?? [];
-            arr.push(cb);
-            listeners.set(evt, arr);
-        },
-        off: (evt, cb) => {
-            const arr = listeners.get(evt);
-            if (!arr) return;
-            const i = arr.indexOf(cb);
-            if (i >= 0) arr.splice(i, 1);
-        },
-        emit: (evt, ...args) => {
-            const arr = listeners.get(evt) ?? [];
-            const snapshot = arr.slice();
-            arr.length = 0;
-            snapshot.forEach((cb) => cb(...args));
-        },
-    };
-}
 
 interface MessagingSettingsOverride {
     whatsapp_enabled?: boolean;
@@ -58,6 +29,7 @@ function makeDeps(opts: {
     vaultInitialized: boolean;
     messaging?: MessagingSettingsOverride;
     sendOutcome?: 'success' | 'fail' | 'partial';
+    waitOutcome?: 'ready' | 'fail' | 'pending';
 }) {
     const vaultRows = opts.vaultInitialized
         ? [{ key: 'wrapped_master_key', value: JSON.stringify('iv:data:tag') }]
@@ -72,9 +44,28 @@ function makeDeps(opts: {
     const settings = { ...defaultMessagingSettings, ...(opts.messaging ?? {}) };
     const loadMessagingSettings = vi.fn().mockResolvedValue(settings);
 
+    let waitForWhatsappReady: ReturnType<typeof vi.fn>;
+    if (opts.waitOutcome === 'fail') {
+        waitForWhatsappReady = vi.fn().mockRejectedValue(new Error('not ready in time'));
+    } else if (opts.waitOutcome === 'pending') {
+        // Caller controls resolution.
+        let resolveFn: () => void = () => { };
+        let rejectFn: (e: Error) => void = () => { };
+        const pending = new Promise<void>((resolve, reject) => {
+            resolveFn = resolve;
+            rejectFn = reject;
+        });
+        waitForWhatsappReady = vi.fn(() => pending);
+        // Stash for tests
+        (waitForWhatsappReady as unknown as { _resolve: () => void; _reject: (e: Error) => void })._resolve = resolveFn;
+        (waitForWhatsappReady as unknown as { _resolve: () => void; _reject: (e: Error) => void })._reject = rejectFn;
+    } else {
+        waitForWhatsappReady = vi.fn().mockResolvedValue(undefined);
+    }
+
     const succeeded =
         opts.sendOutcome === 'fail' ? 0 :
-        opts.sendOutcome === 'partial' ? 1 : 2;
+            opts.sendOutcome === 'partial' ? 1 : 2;
     const sendNotification = vi.fn().mockResolvedValue({
         success: succeeded > 0,
         attempted: 2,
@@ -82,26 +73,12 @@ function makeDeps(opts: {
         results: [],
     });
 
-    return { getDB, queryFn, settings, loadMessagingSettings, sendNotification };
+    return { getDB, queryFn, settings, loadMessagingSettings, sendNotification, waitForWhatsappReady };
 }
 
-const flushMicrotasks = () => new Promise((r) => setImmediate(r));
-
 describe('notifyAppStartedWithLockedVault', () => {
-    let mockClient: MockClient;
-    let getOrCreateClient: ReturnType<typeof vi.fn>;
-
     beforeEach(() => {
         vi.clearAllMocks();
-        mockClient = makeMockClient();
-        getOrCreateClient = vi.fn(() => mockClient);
-        // Default: assume WhatsApp is already up so tests don't need to fire
-        // 'ready' unless they're specifically exercising the wait path.
-        (globalThis as unknown as { whatsappStatus?: string }).whatsappStatus = 'READY';
-    });
-
-    afterEach(() => {
-        delete (globalThis as unknown as { whatsappStatus?: string }).whatsappStatus;
     });
 
     it('does NOT send when the vault is uninitialized (no wrapped key)', async () => {
@@ -110,7 +87,7 @@ describe('notifyAppStartedWithLockedVault', () => {
             messaging: { whatsapp_notify_on_restart: true, whatsapp_to: '972501234567' },
         });
 
-        const result = await notifyAppStartedWithLockedVault({ ...deps, getOrCreateClient });
+        const result = await notifyAppStartedWithLockedVault(deps);
 
         expect(result.sent).toBe(false);
         expect(result.reason).toBe('not_initialized');
@@ -127,7 +104,7 @@ describe('notifyAppStartedWithLockedVault', () => {
             },
         });
 
-        const result = await notifyAppStartedWithLockedVault({ ...deps, getOrCreateClient });
+        const result = await notifyAppStartedWithLockedVault(deps);
 
         expect(result.sent).toBe(false);
         expect(result.reason).toBe('disabled');
@@ -140,7 +117,7 @@ describe('notifyAppStartedWithLockedVault', () => {
             messaging: { whatsapp_notify_on_restart: true, whatsapp_to: '' },
         });
 
-        const result = await notifyAppStartedWithLockedVault({ ...deps, getOrCreateClient });
+        const result = await notifyAppStartedWithLockedVault(deps);
 
         expect(result.sent).toBe(false);
         // No usable channel — same as disabled from the dispatcher's perspective.
@@ -156,11 +133,11 @@ describe('notifyAppStartedWithLockedVault', () => {
 
         const result = await notifyAppStartedWithLockedVault({
             ...deps,
-            getOrCreateClient,
             now: new Date('2026-04-15T10:00:00Z'),
         });
 
         expect(result.sent).toBe(true);
+        expect(deps.waitForWhatsappReady).toHaveBeenCalledTimes(1);
         expect(deps.sendNotification).toHaveBeenCalledTimes(1);
         const call = deps.sendNotification.mock.calls[0][0];
         expect(call.purpose).toBe('restart_notify');
@@ -172,8 +149,8 @@ describe('notifyAppStartedWithLockedVault', () => {
     });
 
     it('sends through the dispatcher for Telegram-only setups (no WA wait)', async () => {
-        // Vault is initialized, only Telegram is opted in; WA must not be
-        // waited for at all — getOrCreateClient should not be called.
+        // Vault is initialized, only Telegram is opted in; WA wait must not be
+        // called at all because nothing is waiting on WhatsApp.
         const deps = makeDeps({
             vaultInitialized: true,
             messaging: {
@@ -184,40 +161,17 @@ describe('notifyAppStartedWithLockedVault', () => {
             },
         });
 
-        const result = await notifyAppStartedWithLockedVault({ ...deps, getOrCreateClient });
+        const result = await notifyAppStartedWithLockedVault(deps);
 
         expect(result.sent).toBe(true);
-        expect(getOrCreateClient).not.toHaveBeenCalled();
+        expect(deps.waitForWhatsappReady).not.toHaveBeenCalled();
         expect(deps.sendNotification).toHaveBeenCalledTimes(1);
     });
 
-    it('waits for ready event when WA is opted-in and still INITIALIZING', async () => {
-        (globalThis as unknown as { whatsappStatus?: string }).whatsappStatus = 'INITIALIZING';
-
+    it('still tries Telegram if WhatsApp wait fails (and TG is opted in)', async () => {
         const deps = makeDeps({
             vaultInitialized: true,
-            messaging: { whatsapp_notify_on_restart: true, whatsapp_to: '972501234567' },
-        });
-
-        const promise = notifyAppStartedWithLockedVault({ ...deps, getOrCreateClient });
-        // Let the function read the DB and reach the wait.
-        await flushMicrotasks();
-        await flushMicrotasks();
-        expect(deps.sendNotification).not.toHaveBeenCalled();
-
-        // Simulate WhatsApp finishing its session restore.
-        mockClient.emit('ready');
-        const result = await promise;
-
-        expect(result.sent).toBe(true);
-        expect(deps.sendNotification).toHaveBeenCalledTimes(1);
-    });
-
-    it('still tries Telegram if WhatsApp auth fails during the wait (and TG is opted in)', async () => {
-        (globalThis as unknown as { whatsappStatus?: string }).whatsappStatus = 'INITIALIZING';
-
-        const deps = makeDeps({
-            vaultInitialized: true,
+            waitOutcome: 'fail',
             messaging: {
                 whatsapp_notify_on_restart: true,
                 whatsapp_to: '972501234567',
@@ -228,30 +182,21 @@ describe('notifyAppStartedWithLockedVault', () => {
             },
         });
 
-        const promise = notifyAppStartedWithLockedVault({ ...deps, getOrCreateClient });
-        await flushMicrotasks();
-
-        mockClient.emit('auth_failure', 'session expired');
-        const result = await promise;
+        const result = await notifyAppStartedWithLockedVault(deps);
 
         // Telegram still went out via the dispatcher.
         expect(result.sent).toBe(true);
         expect(deps.sendNotification).toHaveBeenCalledTimes(1);
     });
 
-    it('drops the notification cleanly if WhatsApp auth fails and TG is not configured', async () => {
-        (globalThis as unknown as { whatsappStatus?: string }).whatsappStatus = 'INITIALIZING';
-
+    it('drops the notification cleanly if WhatsApp wait fails and TG is not configured', async () => {
         const deps = makeDeps({
             vaultInitialized: true,
+            waitOutcome: 'fail',
             messaging: { whatsapp_notify_on_restart: true, whatsapp_to: '972501234567' },
         });
 
-        const promise = notifyAppStartedWithLockedVault({ ...deps, getOrCreateClient });
-        await flushMicrotasks();
-
-        mockClient.emit('auth_failure', 'session expired');
-        const result = await promise;
+        const result = await notifyAppStartedWithLockedVault(deps);
 
         expect(result.sent).toBe(false);
         expect(result.reason).toBe('whatsapp_not_ready');
@@ -269,29 +214,16 @@ describe('notifyAppStartedWithLockedVault', () => {
             whatsapp_to: '972501234567',
         });
         const sendNotification = vi.fn();
+        const waitForWhatsappReady = vi.fn();
 
         const result = await notifyAppStartedWithLockedVault({
             getDB,
             loadMessagingSettings,
             sendNotification,
-            getOrCreateClient,
+            waitForWhatsappReady,
         });
         expect(result.reason).toBe('not_initialized');
         expect(sendNotification).not.toHaveBeenCalled();
-    });
-
-    it('handles the AUTHENTICATED status as ready (not just READY)', async () => {
-        (globalThis as unknown as { whatsappStatus?: string }).whatsappStatus = 'AUTHENTICATED';
-
-        const deps = makeDeps({
-            vaultInitialized: true,
-            messaging: { whatsapp_notify_on_restart: true, whatsapp_to: '972501234567' },
-        });
-
-        const result = await notifyAppStartedWithLockedVault({ ...deps, getOrCreateClient });
-
-        expect(result.sent).toBe(true);
-        // Didn't need to listen for ready — short-circuited.
-        expect(deps.sendNotification).toHaveBeenCalledTimes(1);
+        expect(waitForWhatsappReady).not.toHaveBeenCalled();
     });
 });

--- a/app/utils/whatsapp-client-baileys.js
+++ b/app/utils/whatsapp-client-baileys.js
@@ -1,0 +1,402 @@
+import path from 'path';
+import fs from 'fs';
+import { EventEmitter } from 'events';
+import logger from './logger.js';
+
+/**
+ * Baileys-based WhatsApp client. Same public API as ./whatsapp-client.js
+ * (the legacy whatsapp-web.js implementation), so the transport router can
+ * pick one without anything else in the codebase caring.
+ *
+ * Why Baileys: it speaks WhatsApp's Multi-Device protocol over a WebSocket
+ * directly. No Chromium, no Puppeteer, no SingletonLock files. ~30 MB RSS
+ * vs 250-400 MB for whatsapp-web.js. Sub-second cold start vs 30-90s.
+ *
+ * Auth state lives at .baileys_auth/ (deliberately separate from .wwebjs_auth/
+ * so the two transports can coexist and you can flip between them via the
+ * settings UI without nuking each other's session).
+ */
+
+const AUTH_PATH = path.resolve(process.cwd(), '.baileys_auth');
+const READY_TIMEOUT_MS = 60_000;
+const RECONNECT_BACKOFF_MS = 2_000;
+
+// All process-wide state lives on globalThis so HMR in next dev doesn't make
+// a second client. Mirrors how whatsapp-client.js does it.
+const globalAny = global;
+
+function getState() {
+    return {
+        sock: globalAny.baileysSock || null,
+        status: globalAny.baileysStatus || 'DISCONNECTED', // DISCONNECTED, INITIALIZING, QR_READY, AUTHENTICATED, READY
+        qr: globalAny.baileysQr || null,
+        saveCreds: globalAny.baileysSaveCreds || null,
+        emitter: globalAny.baileysEmitter || null,
+    };
+}
+
+function setStatus(status, extra = {}) {
+    globalAny.baileysStatus = status;
+    if (Object.prototype.hasOwnProperty.call(extra, 'qr')) {
+        globalAny.baileysQr = extra.qr;
+    }
+    // Surface to anything listening (the startup-notify uses the same global
+    // status pattern as the legacy client).
+    globalAny.whatsappStatus = status === 'READY' || status === 'AUTHENTICATED' ? status : globalAny.whatsappStatus;
+}
+
+/**
+ * Tiny pub-sub keyed off node EventEmitter — used by ensureConnected /
+ * waitForReady to await transitions on the singleton without keeping
+ * baileys-specific listeners around.
+ */
+function getEmitter() {
+    if (globalAny.baileysEmitter) return globalAny.baileysEmitter;
+    const emitter = new EventEmitter();
+    emitter.setMaxListeners(50);
+    globalAny.baileysEmitter = emitter;
+    return emitter;
+}
+
+export function hasPersistedSession() {
+    try {
+        const credsPath = path.join(AUTH_PATH, 'creds.json');
+        if (!fs.existsSync(credsPath)) return false;
+        // Empty creds.json = effectively no session (a logged-out state can
+        // leave a zero-byte file behind).
+        const stat = fs.statSync(credsPath);
+        return stat.size > 0;
+    } catch (err) {
+        logger.warn({ err: err.message }, '[baileys] hasPersistedSession check failed');
+        return false;
+    }
+}
+
+export function getStatus() {
+    const s = getState();
+    return {
+        status: s.status,
+        qr: s.qr,
+        timestamp: new Date().toISOString(),
+    };
+}
+
+export function getClient() {
+    return getState().sock;
+}
+
+export function getOrCreateClient() {
+    const existing = getClient();
+    if (existing) return existing;
+    return initializeClient();
+}
+
+/**
+ * Build a fresh socket. Each Baileys socket can only be initialized once;
+ * on reconnect we tear the old one down and call this again.
+ */
+async function buildSock() {
+    // Lazy-load Baileys so the transport router can avoid the cost on
+    // installs that don't use it.
+    const baileys = await import('@whiskeysockets/baileys');
+    // Rename `useMultiFileAuthState` so the React-hooks-rules linter doesn't
+    // mistake it for a misused React hook (it's a Baileys helper that just
+    // happens to follow the `useX` naming convention).
+    const { default: makeWASocket, useMultiFileAuthState: createMultiFileAuthState, fetchLatestBaileysVersion, Browsers } = baileys;
+
+    if (!fs.existsSync(AUTH_PATH)) {
+        fs.mkdirSync(AUTH_PATH, { recursive: true });
+    }
+
+    const { state, saveCreds } = await createMultiFileAuthState(AUTH_PATH);
+    globalAny.baileysSaveCreds = saveCreds;
+
+    const { version } = await fetchLatestBaileysVersion().catch(() => ({ version: undefined }));
+
+    const sock = makeWASocket({
+        version,
+        auth: state,
+        printQRInTerminal: false,
+        // Baileys requires a Pino-shaped logger (debug/info/warn/error/trace
+        // + child()). Our app logger is Pino so it satisfies the contract.
+        logger,
+        browser: Browsers ? Browsers.appropriate?.('Nudlers') ?? Browsers.macOS?.('Nudlers') ?? ['Nudlers', 'Safari', '1.0'] : ['Nudlers', 'Safari', '1.0'],
+        // We send only — never read. Skipping history sync keeps memory
+        // small and avoids the "syncing messages..." stall on reconnect.
+        syncFullHistory: false,
+        markOnlineOnConnect: false,
+        // Bigger value than the default 25 keeps long-lived connections
+        // from churning while idle.
+        keepAliveIntervalMs: 30_000,
+    });
+
+    return sock;
+}
+
+/**
+ * Wire connection.update / creds.update handlers and emit our own
+ * unified status events on the local emitter so callers (ensureConnected,
+ * waitForReady) can await transitions without depending on Baileys.
+ */
+function wireSockEvents(sock) {
+    const emitter = getEmitter();
+
+    sock.ev.on('creds.update', async () => {
+        const s = getState();
+        if (s.saveCreds) {
+            try { await s.saveCreds(); } catch (err) {
+                logger.warn({ err: err.message }, '[baileys] saveCreds failed');
+            }
+        }
+    });
+
+    sock.ev.on('connection.update', async (update) => {
+        const { connection, lastDisconnect, qr } = update;
+
+        if (qr) {
+            logger.info('[baileys] QR code generated');
+            setStatus('QR_READY', { qr });
+            emitter.emit('qr', qr);
+        }
+
+        if (connection === 'open') {
+            logger.info('[baileys] Connection ready');
+            setStatus('READY', { qr: null });
+            // Mirror the legacy global so whatsappStartupNotify's
+            // waitForWhatsAppReady() short-circuits cleanly.
+            globalAny.whatsappStatus = 'READY';
+            emitter.emit('ready');
+        }
+
+        if (connection === 'connecting') {
+            // Don't downgrade an already-READY status to INITIALIZING just
+            // because Baileys ticked through 'connecting' during a routine
+            // network blip.
+            if (getState().status !== 'READY' && getState().status !== 'AUTHENTICATED') {
+                setStatus('INITIALIZING');
+            }
+        }
+
+        if (connection === 'close') {
+            const code = lastDisconnect?.error?.output?.statusCode
+                ?? lastDisconnect?.error?.output?.payload?.statusCode;
+            // 401 = DisconnectReason.loggedOut — the only code where a
+            // reconnect can't help; user must scan a fresh QR. Hardcoded
+            // because doing `await import('@whiskeysockets/baileys')` here
+            // would defer the rest of this handler past the reconnect
+            // window for callers using fake timers.
+            const loggedOut = code === 401;
+            const reason = lastDisconnect?.error?.message || 'unknown';
+
+            logger.warn({ code, reason, loggedOut }, '[baileys] Connection closed');
+            globalAny.whatsappStatus = 'DISCONNECTED';
+            setStatus('DISCONNECTED', { qr: null });
+            emitter.emit('disconnected', { code, reason, loggedOut });
+
+            // On loggedOut, the saved session is dead — only a fresh QR scan
+            // helps. Don't auto-reconnect (we'd just spin up another socket
+            // and immediately get kicked again).
+            if (loggedOut) {
+                logger.warn('[baileys] Session is logged out — clearing creds, fresh QR required');
+                try { fs.rmSync(AUTH_PATH, { recursive: true, force: true }); } catch { /* swallow */ }
+                globalAny.baileysSock = null;
+                return;
+            }
+
+            // Anything else: drop the dead socket and rebuild after a small
+            // backoff. Baileys does NOT auto-reconnect for you.
+            globalAny.baileysSock = null;
+            setTimeout(() => {
+                initializeClient().catch((err) => {
+                    logger.error({ err: err.message }, '[baileys] auto-reconnect failed');
+                });
+            }, RECONNECT_BACKOFF_MS);
+        }
+    });
+
+    // Our public API exposes off()/once() in waitForReady semantics; bridge
+    // those through the emitter rather than Baileys's sock.ev to keep them
+    // under our control.
+    return {
+        once: (evt, cb) => emitter.once(evt, cb),
+        off: (evt, cb) => emitter.off(evt, cb),
+        on: (evt, cb) => emitter.on(evt, cb),
+    };
+}
+
+export async function initializeClient() {
+    const existing = getState().sock;
+    if (existing) {
+        logger.info('[baileys] Client already exists, returning existing instance');
+        return existing;
+    }
+
+    const hasSession = hasPersistedSession();
+    logger.info({ hasPersistedSession: hasSession }, '[baileys] Initializing new client');
+
+    setStatus('INITIALIZING');
+    globalAny.whatsappStatus = 'INITIALIZING';
+
+    try {
+        const sock = await buildSock();
+        wireSockEvents(sock);
+        globalAny.baileysSock = sock;
+        return sock;
+    } catch (err) {
+        logger.error({ err: err.message, stack: err.stack }, '[baileys] Initialization failed');
+        setStatus('DISCONNECTED', { qr: null });
+        globalAny.whatsappStatus = 'DISCONNECTED';
+        globalAny.baileysSock = null;
+        throw err;
+    }
+}
+
+export async function destroyClient() {
+    const sock = getState().sock;
+    if (!sock) return;
+    try {
+        // logout() actually logs the session out of WhatsApp servers — we
+        // don't want that, just the local close. end() with no args is the
+        // safe shutdown that preserves auth state.
+        if (typeof sock.end === 'function') {
+            sock.end(undefined);
+        } else if (typeof sock.ws?.close === 'function') {
+            sock.ws.close();
+        }
+    } catch (err) {
+        logger.warn({ err: err.message }, '[baileys] error tearing down socket');
+    }
+    globalAny.baileysSock = null;
+    setStatus('DISCONNECTED', { qr: null });
+    globalAny.whatsappStatus = 'DISCONNECTED';
+}
+
+export async function restartClient() {
+    logger.info('[baileys] Restarting client');
+    await destroyClient();
+    // Brief pause so the underlying socket really finishes closing before
+    // we open the next one and trip into the same connection slot.
+    await new Promise((r) => setTimeout(r, 1000));
+    return initializeClient();
+}
+
+export function clearSession() {
+    try {
+        if (fs.existsSync(AUTH_PATH)) {
+            logger.info({ AUTH_PATH }, '[baileys] Clearing persisted session');
+            fs.rmSync(AUTH_PATH, { recursive: true, force: true });
+            return true;
+        }
+        return true;
+    } catch (err) {
+        logger.error({ err: err.message }, '[baileys] Failed to clear session');
+        return false;
+    }
+}
+
+export async function renewQrCode() {
+    logger.info('[baileys] Renewing QR code');
+    await destroyClient();
+    clearSession();
+    await new Promise((r) => setTimeout(r, 500));
+    return initializeClient();
+}
+
+/**
+ * Wait for the socket to reach READY. Mirrors the contract on the legacy
+ * client: resolve on ready, reject on auth_failure or timeout.
+ *
+ * Also exported below as `waitForReady` so the transport router can proxy
+ * a uniform "wait for the active transport to be ready" call regardless of
+ * which implementation is loaded.
+ */
+function waitForReadyInternal(timeoutMs) {
+    return new Promise((resolve, reject) => {
+        const emitter = getEmitter();
+
+        // Already ready? Short-circuit.
+        if (getState().status === 'READY' || getState().status === 'AUTHENTICATED') {
+            return resolve();
+        }
+
+        const cleanup = () => {
+            clearTimeout(timer);
+            emitter.off('ready', onReady);
+            emitter.off('disconnected', onDisconnected);
+        };
+        const onReady = () => { cleanup(); resolve(); };
+        const onDisconnected = ({ loggedOut, reason }) => {
+            if (loggedOut) {
+                cleanup();
+                reject(new Error(`Baileys auth failure (logged out): ${reason}`));
+            }
+            // Non-fatal disconnects auto-reconnect; keep waiting.
+        };
+        const timer = setTimeout(() => {
+            cleanup();
+            reject(new Error(`Baileys client did not become ready within ${timeoutMs}ms`));
+        }, timeoutMs);
+
+        emitter.once('ready', onReady);
+        emitter.on('disconnected', onDisconnected);
+    });
+}
+
+export async function ensureConnected({ timeoutMs = READY_TIMEOUT_MS } = {}) {
+    const existing = getClient();
+    if (existing && (getState().status === 'READY' || getState().status === 'AUTHENTICATED')) {
+        return existing;
+    }
+
+    if (!existing) {
+        logger.info('[baileys] No socket — initializing before send');
+        await initializeClient();
+    } else {
+        logger.warn({ status: getState().status }, '[baileys] Socket not READY — waiting');
+    }
+
+    await waitForReadyInternal(timeoutMs);
+    return getClient();
+}
+
+export function waitForReady({ timeoutMs = READY_TIMEOUT_MS } = {}) {
+    if (!getClient()) {
+        // Kick off init in the background so the wait actually has a chance
+        // of succeeding. ensureConnected() does the same thing internally.
+        initializeClient().catch(() => { /* errors surface via emitter */ });
+    }
+    return waitForReadyInternal(timeoutMs);
+}
+
+/**
+ * Transport-uniform send. Baileys takes a JID + a message-content object
+ * (`{ text }`) and returns `{ key: { id } }`; we project that into the same
+ * `{ id }` shape the legacy client's sendText returns so whatsapp.js doesn't
+ * have to care which transport answered.
+ */
+export async function sendText({ client, chatId, body }) {
+    const sent = await client.sendMessage(chatId, { text: body });
+    return { id: sent?.key?.id ?? '' };
+}
+
+/**
+ * Auto-restore on module load — mirrors the legacy client's startup hook.
+ * If the transport router lazy-imports this file (it does), the load only
+ * happens when transport === 'baileys'.
+ */
+function autoRestoreSession() {
+    if (getClient()) return;
+    if (globalAny.baileysAutoRestoreAttempted) return;
+    globalAny.baileysAutoRestoreAttempted = true;
+
+    if (hasPersistedSession()) {
+        logger.info('[baileys] Auto-restoring session from disk');
+        initializeClient().catch((err) => {
+            logger.error({ err: err.message }, '[baileys] auto-restore failed');
+        });
+    } else {
+        logger.info('[baileys] No persisted session — will initialize on demand');
+    }
+}
+
+autoRestoreSession();

--- a/app/utils/whatsapp-client.js
+++ b/app/utils/whatsapp-client.js
@@ -275,7 +275,7 @@ const READY_TIMEOUT_MS = 60000;
  * Wait until `ready` fires (or `auth_failure` / timeout). Used by ensureConnected()
  * after a fresh init to confirm the client is actually usable, not just constructed.
  */
-function waitForReady(client, timeoutMs) {
+function waitForReadyOnClient(client, timeoutMs) {
     return new Promise((resolve, reject) => {
         const cleanup = () => {
             clearTimeout(timer);
@@ -320,9 +320,34 @@ export async function ensureConnected({ timeoutMs = READY_TIMEOUT_MS } = {}) {
     }
 
     const fresh = await restartClient();
-    await waitForReady(fresh, timeoutMs);
+    await waitForReadyOnClient(fresh, timeoutMs);
     logger.info('WhatsApp client reconnected and ready');
     return fresh;
+}
+
+/**
+ * Public-facing waitForReady used by the startup-notify path and by anyone
+ * else who wants to await a transport's READY state without holding onto
+ * the underlying client object. Mirrors the same export on the Baileys
+ * client so the transport router can proxy either one.
+ */
+export function waitForReady({ timeoutMs = READY_TIMEOUT_MS } = {}) {
+    const status = globalAny.whatsappStatus || connectionStatus;
+    if (status === 'READY' || status === 'AUTHENTICATED') {
+        return Promise.resolve();
+    }
+    const client = getOrCreateClient();
+    return waitForReadyOnClient(client, timeoutMs);
+}
+
+/**
+ * Transport-uniform send. Wraps the whatsapp-web.js client.sendMessage call
+ * so callers don't have to care which transport they're talking to.
+ * Returns `{ id }` — a stable shape across both implementations.
+ */
+export async function sendText({ client, chatId, body }) {
+    const message = await client.sendMessage(chatId, body);
+    return { id: message?.id?._serialized ?? '' };
 }
 
 /**

--- a/app/utils/whatsapp-transport.js
+++ b/app/utils/whatsapp-transport.js
@@ -1,0 +1,183 @@
+import logger from './logger.js';
+
+/**
+ * WhatsApp transport router. Picks one implementation per process based on
+ * the `whatsapp_transport` setting and proxies the rest of the codebase to
+ * it through a stable API.
+ *
+ * Two transports:
+ *   'web'     → whatsapp-web.js (Puppeteer/Chromium, legacy)
+ *   'baileys' → @whiskeysockets/baileys (direct WebSocket, recommended)
+ *
+ * The transport choice is *cached for the life of the process*. Switching
+ * transports at runtime is a settings save → restart-the-client operation,
+ * not a hot-swap, because each implementation owns its own auth state and
+ * its own auto-restore-on-import side effect. We don't want both modules
+ * loaded simultaneously fighting for the same singleton.
+ *
+ * Safe defaults: if reading the setting fails (DB down at boot, etc.) we
+ * fall back to 'web' rather than crashing. The legacy client is what
+ * existing installs are running, so a fallback to it preserves behaviour.
+ */
+
+const FALLBACK_TRANSPORT = 'web';
+
+let cachedTransport = null;     // 'web' | 'baileys'
+let cachedModule = null;        // resolved transport module
+let resolveOnce = null;         // shared in-flight Promise so concurrent callers don't race
+
+async function readTransportSetting() {
+    try {
+        const { getDB } = await import('../pages/api/db.js');
+        const client = await getDB();
+        try {
+            const result = await client.query(
+                "SELECT value FROM app_settings WHERE key = 'whatsapp_transport'"
+            );
+            const raw = result.rows[0]?.value;
+            if (raw === undefined || raw === null) return FALLBACK_TRANSPORT;
+            // jsonb returns parsed values from pg already. Strings come back
+            // as strings (because they were JSON.stringified to '"web"' on
+            // write); strip surrounding quotes if present.
+            let v = raw;
+            if (typeof v === 'string') {
+                try { v = JSON.parse(v); } catch { /* fall through */ }
+            }
+            const normalised = String(v || '').toLowerCase().trim();
+            if (normalised === 'baileys' || normalised === 'web') return normalised;
+            logger.warn({ raw }, '[whatsapp-transport] Unknown transport value, falling back');
+            return FALLBACK_TRANSPORT;
+        } finally {
+            try { client.release(); } catch { /* ignore */ }
+        }
+    } catch (err) {
+        logger.warn({ err: err.message }, '[whatsapp-transport] Failed to read setting, falling back to web');
+        return FALLBACK_TRANSPORT;
+    }
+}
+
+/**
+ * Resolve the transport module. Memoized; safe to call concurrently —
+ * we keep a single in-flight Promise so we never load both modules.
+ */
+function ensureTransport() {
+    if (cachedModule) return Promise.resolve(cachedModule);
+    if (resolveOnce) return resolveOnce;
+    resolveOnce = (async () => {
+        const transport = await readTransportSetting();
+        cachedTransport = transport;
+        logger.info({ transport }, '[whatsapp-transport] Loading transport module');
+        const mod = transport === 'baileys'
+            ? await import('./whatsapp-client-baileys.js')
+            : await import('./whatsapp-client.js');
+        cachedModule = mod;
+        return mod;
+    })();
+    return resolveOnce;
+}
+
+// Kick off resolution as soon as this module loads. Importers don't have to
+// await anything for the chosen transport's auto-restore side effects to
+// fire — they happen the moment we dynamic-import the module.
+ensureTransport().catch((err) => {
+    logger.error({ err: err.message }, '[whatsapp-transport] Initial resolve failed');
+});
+
+/**
+ * Sync API — returns safe defaults until the transport is resolved.
+ * Production code that depends on these (status polling, etc.) tolerates
+ * a brief 'DISCONNECTED' window during the first ~50ms after boot.
+ */
+export function getStatus() {
+    if (!cachedModule) {
+        return { status: 'DISCONNECTED', qr: null, timestamp: new Date().toISOString() };
+    }
+    return cachedModule.getStatus();
+}
+
+export function getClient() {
+    if (!cachedModule) return null;
+    return cachedModule.getClient();
+}
+
+export function hasPersistedSession() {
+    if (!cachedModule) return false;
+    return cachedModule.hasPersistedSession();
+}
+
+export function getActiveTransport() {
+    return cachedTransport;
+}
+
+/**
+ * Async API — awaits the transport module, then delegates. Anything that
+ * actually does work (initialize, send-prep, restart) goes through here.
+ */
+export async function initializeClient() {
+    const m = await ensureTransport();
+    return m.initializeClient();
+}
+
+export async function getOrCreateClient() {
+    const m = await ensureTransport();
+    return m.getOrCreateClient();
+}
+
+export async function destroyClient() {
+    const m = await ensureTransport();
+    return m.destroyClient();
+}
+
+export async function restartClient() {
+    const m = await ensureTransport();
+    return m.restartClient();
+}
+
+export async function clearSession() {
+    const m = await ensureTransport();
+    return m.clearSession();
+}
+
+export async function renewQrCode() {
+    const m = await ensureTransport();
+    return m.renewQrCode();
+}
+
+export async function ensureConnected(opts) {
+    const m = await ensureTransport();
+    return m.ensureConnected(opts);
+}
+
+export async function waitForReady(opts) {
+    const m = await ensureTransport();
+    return m.waitForReady(opts);
+}
+
+export async function sendText(args) {
+    const m = await ensureTransport();
+    return m.sendText(args);
+}
+
+/**
+ * Force the router to re-read the transport setting and swap implementation.
+ * Used by /api/whatsapp/transport when the user changes the setting in the
+ * UI. Tears down the current transport's client first so we don't leak a
+ * Chromium/socket that nothing else owns anymore.
+ *
+ * Note: switching transports throws away the current session (each transport
+ * has its own auth dir; we deliberately don't migrate). The caller is
+ * responsible for prompting the user to scan a fresh QR.
+ */
+export async function reloadTransport() {
+    if (cachedModule) {
+        try {
+            await cachedModule.destroyClient();
+        } catch (err) {
+            logger.warn({ err: err.message }, '[whatsapp-transport] destroy on reload failed');
+        }
+    }
+    cachedModule = null;
+    cachedTransport = null;
+    resolveOnce = null;
+    return ensureTransport();
+}

--- a/app/utils/whatsapp.js
+++ b/app/utils/whatsapp.js
@@ -1,5 +1,5 @@
 import logger from './logger.js';
-import { ensureConnected } from './whatsapp-client.js';
+import { ensureConnected, sendText } from './whatsapp-transport.js';
 
 /**
  * Heuristic: errors that look like the WA web page is gone (frame detached,
@@ -7,29 +7,33 @@ import { ensureConnected } from './whatsapp-client.js';
  * a reconnect is the only thing that will help. Other errors (`recipient is
  * not a contact`, `chatId not found`) are user-visible and shouldn't trigger
  * a reconnect retry, since reconnecting won't help.
+ *
+ * Also matches Baileys-side transient symptoms (`connection closed`,
+ * `socket closed`, `stream errored`) so the same retry path applies when
+ * the WebSocket transport happens to die mid-send.
  */
 function looksLikeTransientClientDeath(err) {
     const msg = (err && err.message) ? String(err.message) : String(err);
-    return /frame|detached|target closed|page closed|protocol error|session closed|execution context|navigation/i.test(msg);
+    return /frame|detached|target closed|page closed|protocol error|session closed|execution context|navigation|connection closed|stream errored|socket (closed|hang up)|websocket/i.test(msg);
 }
 
 const TRANSIENT_RETRY_DELAY_MS = 1500;
 
 /**
- * Sends a WhatsApp message using the internal singleton client.
+ * Sends a WhatsApp message. The transport router (whatsapp-transport.js)
+ * picks the underlying implementation; we don't care which.
  *
  * Resilience model:
- *  1. ensureConnected() probes the client and reconnects up front. This
- *     handles the "client wasn't running" case.
- *  2. If sendMessage *itself* throws something that looks like a dead-page
+ *  1. ensureConnected() probes the transport and reconnects up front.
+ *  2. If sendText *itself* throws something that looks like a dead-transport
  *     error AFTER ensureConnected said we were good, we force one more
- *     reconnect-and-retry. This catches the narrow window where the page
- *     died between the probe and the send.
+ *     reconnect-and-retry. This catches the narrow window where the
+ *     underlying socket/page died between the probe and the send.
  *
  * Why not retry every error type? Errors like "recipient not in contacts"
  * or "invalid chat id" are deterministic — retrying just doubles the noise
- * in the logs and might cause duplicate sends if Puppeteer succeeded but
- * couldn't read back the response.
+ * in the logs and might cause duplicate sends if the server accepted the
+ * first attempt but couldn't read back the response.
  *
  * @param {Object} options
  * @param {string} options.to    Comma-separated recipients ('whatsapp:+972…',
@@ -58,24 +62,24 @@ export async function sendWhatsAppMessage({ to, body }) {
             }
 
             try {
-                const message = await client.sendMessage(chatId, body);
-                logger.info({ to: recipient, chatId, messageId: message.id._serialized }, 'WhatsApp message sent successfully');
-                results.push({ success: true, to: recipient, messageId: message.id._serialized });
+                const sent = await sendText({ client, chatId, body });
+                logger.info({ to: recipient, chatId, messageId: sent.id }, 'WhatsApp message sent successfully');
+                results.push({ success: true, to: recipient, messageId: sent.id });
             } catch (sendError) {
                 if (looksLikeTransientClientDeath(sendError)) {
                     logger.warn(
                         { to: recipient, err: sendError.message },
-                        'WhatsApp send hit a transient client-death error; reconnecting and retrying once'
+                        'WhatsApp send hit a transient transport-death error; reconnecting and retrying once'
                     );
                     try {
                         await new Promise((r) => setTimeout(r, TRANSIENT_RETRY_DELAY_MS));
                         client = await ensureConnected();
-                        const message = await client.sendMessage(chatId, body);
+                        const sent = await sendText({ client, chatId, body });
                         logger.info(
-                            { to: recipient, chatId, messageId: message.id._serialized },
+                            { to: recipient, chatId, messageId: sent.id },
                             'WhatsApp message sent on retry'
                         );
-                        results.push({ success: true, to: recipient, messageId: message.id._serialized, retried: true });
+                        results.push({ success: true, to: recipient, messageId: sent.id, retried: true });
                         continue;
                     } catch (retryErr) {
                         logger.error(

--- a/app/utils/whatsappStartupNotify.js
+++ b/app/utils/whatsappStartupNotify.js
@@ -25,7 +25,7 @@ export async function notifyAppStartedWithLockedVault(opts = {}) {
     const {
         getDB,
         sendNotification,
-        getOrCreateClient,
+        waitForWhatsappReady,
         loadMessagingSettings,
         now,
     } = await resolveDependencies(opts);
@@ -61,15 +61,15 @@ export async function notifyAppStartedWithLockedVault(opts = {}) {
         return { sent: false, reason: 'disabled' };
     }
 
-    // If WhatsApp wants the message, wait for the WA client to be ready before
-    // dispatching — Telegram doesn't need this, but the dispatcher fires both
-    // in parallel so the slowest one sets the latency floor anyway.
+    // If WhatsApp wants the message, wait for the active WA transport
+    // (legacy or Baileys) to reach READY before dispatching. Telegram
+    // doesn't need this; if WA is the only enabled channel and it never
+    // becomes ready, we drop the notification cleanly.
     if (wantsWhatsapp) {
         try {
-            await waitForWhatsAppReady({ getOrCreateClient, timeoutMs: READY_TIMEOUT_MS });
+            await waitForWhatsappReady({ timeoutMs: READY_TIMEOUT_MS });
         } catch (err) {
             logger.warn({ err: err.message }, '[startup-notify] WhatsApp not ready in time — Telegram (if configured) will still try');
-            // Don't bail; if Telegram is enabled it can still deliver.
             if (!wantsTelegram) {
                 return { sent: false, reason: 'whatsapp_not_ready' };
             }
@@ -109,7 +109,7 @@ async function resolveDependencies(overrides) {
     if (
         overrides.getDB &&
         overrides.sendNotification &&
-        overrides.getOrCreateClient &&
+        overrides.waitForWhatsappReady &&
         overrides.loadMessagingSettings
     ) {
         return overrides;
@@ -117,55 +117,12 @@ async function resolveDependencies(overrides) {
     const dbModule = await import('../pages/api/db.js');
     const dispatcherModule = await import('./messaging/dispatcher.js');
     const settingsModule = await import('./messaging/settings.js');
-    const waClientModule = await import('./whatsapp-client.js');
+    const transportModule = await import('./whatsapp-transport.js');
     return {
         getDB: overrides.getDB || dbModule.getDB,
         sendNotification: overrides.sendNotification || dispatcherModule.sendNotification,
         loadMessagingSettings: overrides.loadMessagingSettings || settingsModule.loadMessagingSettings,
-        getOrCreateClient: overrides.getOrCreateClient || waClientModule.getOrCreateClient,
+        waitForWhatsappReady: overrides.waitForWhatsappReady || transportModule.waitForReady,
         now: overrides.now,
     };
-}
-
-/**
- * Resolve when the WhatsApp client is READY (or AUTHENTICATED). Short-circuits
- * if it's already there. Otherwise listens for the underlying client's events
- * with a hard timeout so we never hang forever on a vault that needs a fresh
- * QR scan.
- */
-function waitForWhatsAppReady({ getOrCreateClient, timeoutMs }) {
-    const globalAny = globalThis;
-    const isReady = () => {
-        const s = globalAny.whatsappStatus;
-        return s === 'READY' || s === 'AUTHENTICATED';
-    };
-    if (isReady()) return Promise.resolve();
-
-    const client = getOrCreateClient();
-    return new Promise((resolve, reject) => {
-        const cleanup = () => {
-            clearTimeout(timer);
-            client.off?.('ready', onReady);
-            client.off?.('authenticated', onAuthed);
-            client.off?.('auth_failure', onFail);
-        };
-        const onReady = () => { cleanup(); resolve(); };
-        const onAuthed = () => { cleanup(); resolve(); };
-        const onFail = (msg) => { cleanup(); reject(new Error(`WhatsApp authentication failure: ${msg}`)); };
-        const timer = setTimeout(() => {
-            cleanup();
-            reject(new Error(`WhatsApp client did not become ready within ${timeoutMs}ms`));
-        }, timeoutMs);
-        client.once('ready', onReady);
-        client.once('authenticated', onAuthed);
-        client.once('auth_failure', onFail);
-
-        // Closes the TOCTOU race: between the initial isReady() above and the
-        // listener registration, the underlying client could have fired the
-        // event we'd otherwise miss. Re-check now that we're listening.
-        if (isReady()) {
-            cleanup();
-            resolve();
-        }
-    });
 }


### PR DESCRIPTION
## Summary

Adds **Baileys** (`@whiskeysockets/baileys`) as an alternative WhatsApp transport, swappable at runtime via a `whatsapp_transport` setting. Replaces nothing yet — the flag defaults to `web` so existing installs upgrade with zero behaviour change. Users opt into Baileys from the Settings modal; the UI prompts for a fresh QR scan because each transport has its own auth dir.

> **Re-opening:** the original PR (#102) accidentally merged into the stale `feat/messaging-providers` branch instead of `main`, so the Baileys code never reached `main`. This PR is the rebased branch pointed at `main` directly. Single clean commit on top of current main.

## Why Baileys

| Pain on whatsapp-web.js | Baileys |
|------------------------|---------|
| 250–400 MB RSS | ~30 MB |
| 30–90s startup | sub-second |
| Random "frame detached" errors | no DOM, no iframes |
| Stale `SingletonLock` files | no Chromium |
| Puppeteer + Chromium upgrade pain | direct WebSocket |

## What's in

- **`app/utils/whatsapp-client-baileys.js`** — Baileys client mirroring the legacy `whatsapp-client.js` public API exactly (`getClient`, `getOrCreateClient`, `getStatus`, `initializeClient`, `destroyClient`, `restartClient`, `clearSession`, `renewQrCode`, `ensureConnected`, `hasPersistedSession`, `waitForReady`, `sendText`). Auth state at `.baileys_auth/`. Auto-reconnects on non-loggedOut closes; clears creds + waits for fresh QR on 401.
- **`app/utils/whatsapp-transport.js`** — Router. Reads `whatsapp_transport` once, lazy-imports the chosen module, exposes the same API. Memoized for process lifetime; `reloadTransport()` is the hot-swap path.
- **Unified `sendText({ client, chatId, body }) → { id }`** — both transports export this; `whatsapp.js` calls it through the router. Callers stop caring about transport.
- **Migration 015** — seeds `whatsapp_transport='web'` (safe default).
- **`/api/whatsapp/transport`** (`GET`/`POST`) — persists the choice + calls `reloadTransport()`.
- **`/api/whatsapp/status`** — now also returns the active transport.
- **SettingsModal** — transport selector with a `window.confirm` warning about the QR re-scan. en + he.
- **Production rewiring** — `whatsapp.js`, status API, `instrumentation.ts`, and `whatsappStartupNotify` all route through the transport router.
- **`waitForReady`** — uniform export on both transports + router, replacing the legacy event-listener wait pattern in startup-notify.

## What's NOT in (deliberately)

- **Default transport flip.** Stays `web` until you've validated Baileys on your install for ≥ a week. Flipping to `baileys` is a 1-line follow-up commit.
- **Auto-migration of `.wwebjs_auth/`.** Different protocols; can't carry session bytes over.
- **Cleanup of the legacy code path.** Stays in the repo as a one-line rollback (set `whatsapp_transport='web'` in the DB).

## Test plan

- [x] Full vitest suite: 751/751 green (+11 Baileys client tests, plus the anomaly tests already on main).
- [x] Lint clean on all touched files.
- [x] tsc --noEmit clean on all touched files.
- [ ] After deploy with default `web`, run for a few hours — confirm zero regressions vs the previous build.
- [ ] In settings, switch transport to `baileys`. Confirm dialog appears. Status indicator goes to INITIALIZING then QR_READY.
- [ ] Scan the new QR. Status reaches READY. Verify with the WhatsApp test button.
- [ ] Trigger the daily summary cron. Confirm it fires through Baileys.
- [ ] Restart the server with the vault locked. Confirm the restart-notify reaches you (Baileys + Telegram if both enabled).
- [ ] Switch back to `web`. Confirm fallback works without code changes.
- [ ] Memory check: `ps -o rss= -p <pid>` after each transport. Expect a ~10x drop on Baileys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)