### PR TITLE
fix(whatsapp): coalesce concurrent Baileys init + skip auto-reconnect on conflict

### DIFF
--- a/app/tests/whatsapp-client.test.ts
+++ b/app/tests/whatsapp-client.test.ts
@@ -82,6 +82,7 @@ function clearBaileysGlobals() {
     delete g.baileysSaveCreds;
     delete g.baileysEmitter;
     delete g.baileysAutoRestoreAttempted;
+    delete g.baileysInitInFlight;
     delete g.whatsappStatus;
 }
 
@@ -138,6 +139,42 @@ describe('whatsapp-client', () => {
         // Microtask flush so the async handler runs.
         await new Promise((r) => setImmediate(r));
         expect(saveCredsMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT auto-reconnect on a connectionReplaced close (avoids fight loop)', async () => {
+        const mod = await import('../utils/whatsapp-client.js');
+        await mod.initializeClient();
+        expect(makeWASocketMock).toHaveBeenCalledTimes(1);
+
+        lastMockSock!.ev.emit('connection.update', {
+            connection: 'close',
+            lastDisconnect: { error: { output: { statusCode: 440 } } }, // connectionReplaced
+        });
+
+        // Backoff plus padding — would have rebuilt by now if we
+        // (mistakenly) auto-reconnected.
+        await new Promise((r) => setTimeout(r, 2_500));
+        expect(makeWASocketMock).toHaveBeenCalledTimes(1);
+        expect(mod.getStatus().status).toBe('DISCONNECTED');
+    }, 10_000);
+
+    it('coalesces concurrent initializeClient() calls into one socket', async () => {
+        // The bug this guards: at boot, autoRestoreSession() fires
+        // initializeClient() unawaited, then instrumentation.ts's pre-warm
+        // calls ensureConnected() → initializeClient() before the first
+        // call has finished buildSock(). Without an in-flight guard, both
+        // run buildSock and we end up with two sockets logging in with the
+        // same creds — WhatsApp evicts one with `conflict: replaced`.
+        const mod = await import('../utils/whatsapp-client.js');
+        const [a, b, c] = await Promise.all([
+            mod.initializeClient(),
+            mod.initializeClient(),
+            mod.initializeClient(),
+        ]);
+        expect(makeWASocketMock).toHaveBeenCalledTimes(1);
+        // All three callers share the exact same socket reference.
+        expect(a).toBe(b);
+        expect(b).toBe(c);
     });
 
     it('does NOT auto-reconnect on a loggedOut close (clears session instead)', async () => {

--- a/app/utils/whatsapp-client.js
+++ b/app/utils/whatsapp-client.js
@@ -180,18 +180,23 @@ function wireSockEvents(sock) {
         if (connection === 'close') {
             const code = lastDisconnect?.error?.output?.statusCode
                 ?? lastDisconnect?.error?.output?.payload?.statusCode;
-            // 401 = DisconnectReason.loggedOut — the only code where a
-            // reconnect can't help; user must scan a fresh QR. Hardcoded
-            // because doing `await import('@whiskeysockets/baileys')` here
-            // would defer the rest of this handler past the reconnect
-            // window for callers using fake timers.
+            // Hardcoded reason codes (Baileys's DisconnectReason values).
+            // Doing `await import('@whiskeysockets/baileys')` here would
+            // defer the rest of this handler past the reconnect window
+            // for callers using fake timers.
+            //   401 = loggedOut          — session dead, fresh QR needed
+            //   440 = connectionReplaced — another client took over our
+            //                              creds; reconnecting just makes
+            //                              us fight that other client in
+            //                              a loop kicking each other off
             const loggedOut = code === 401;
+            const replaced = code === 440;
             const reason = lastDisconnect?.error?.message || 'unknown';
 
-            logger.warn({ code, reason, loggedOut }, '[baileys] Connection closed');
+            logger.warn({ code, reason, loggedOut, replaced }, '[baileys] Connection closed');
             globalAny.whatsappStatus = 'DISCONNECTED';
             setStatus('DISCONNECTED', { qr: null });
-            emitter.emit('disconnected', { code, reason, loggedOut });
+            emitter.emit('disconnected', { code, reason, loggedOut, replaced });
 
             // On loggedOut, the saved session is dead — only a fresh QR scan
             // helps. Don't auto-reconnect (we'd just spin up another socket
@@ -199,6 +204,15 @@ function wireSockEvents(sock) {
             if (loggedOut) {
                 logger.warn('[baileys] Session is logged out — clearing creds, fresh QR required');
                 try { fs.rmSync(AUTH_PATH, { recursive: true, force: true }); } catch { /* swallow */ }
+                globalAny.baileysSock = null;
+                return;
+            }
+
+            // On `replaced`, another instance is using our creds. Reconnecting
+            // restarts the conflict loop. Sit idle and let an operator
+            // resolve it (kill the duplicate process, or scan a new QR).
+            if (replaced) {
+                logger.warn('[baileys] Session was replaced by another client; not auto-reconnecting');
                 globalAny.baileysSock = null;
                 return;
             }
@@ -231,24 +245,42 @@ export async function initializeClient() {
         return existing;
     }
 
+    // Coalesce concurrent init attempts onto one in-flight Promise. Two
+    // callers (autoRestoreSession at module load racing with
+    // ensureConnected from instrumentation.ts's pre-warm) must NEVER both
+    // run buildSock — they'd open two sockets logging in with the same
+    // credentials, WhatsApp's MD protocol responds with
+    // `stream:error -> conflict (type: replaced)`, and our auto-reconnect
+    // makes the two sockets fight in a loop kicking each other off.
+    if (globalAny.baileysInitInFlight) {
+        logger.info('[baileys] Initialization already in flight; awaiting');
+        return globalAny.baileysInitInFlight;
+    }
+
     const hasSession = hasPersistedSession();
     logger.info({ hasPersistedSession: hasSession }, '[baileys] Initializing new client');
 
     setStatus('INITIALIZING');
     globalAny.whatsappStatus = 'INITIALIZING';
 
-    try {
-        const sock = await buildSock();
-        wireSockEvents(sock);
-        globalAny.baileysSock = sock;
-        return sock;
-    } catch (err) {
-        logger.error({ err: err.message, stack: err.stack }, '[baileys] Initialization failed');
-        setStatus('DISCONNECTED', { qr: null });
-        globalAny.whatsappStatus = 'DISCONNECTED';
-        globalAny.baileysSock = null;
-        throw err;
-    }
+    globalAny.baileysInitInFlight = (async () => {
+        try {
+            const sock = await buildSock();
+            wireSockEvents(sock);
+            globalAny.baileysSock = sock;
+            return sock;
+        } catch (err) {
+            logger.error({ err: err.message, stack: err.stack }, '[baileys] Initialization failed');
+            setStatus('DISCONNECTED', { qr: null });
+            globalAny.whatsappStatus = 'DISCONNECTED';
+            globalAny.baileysSock = null;
+            throw err;
+        } finally {
+            globalAny.baileysInitInFlight = null;
+        }
+    })();
+
+    return globalAny.baileysInitInFlight;
 }
 
 export async function destroyClient() {


### PR DESCRIPTION
## Symptom in production after #104

```
{"reasonNode":{"tag":"conflict","attrs":{"type":"replaced"}},"msg":"stream errored out"}
Error: Stream Errored (conflict)
    at WebSocketClient.<anonymous> (file:///app/node_modules/@whiskeysockets/baileys/lib/Socket/socket.js:792:18)
```
…in a loop, because we auto-reconnect on every non-loggedOut close.

## Root cause

PR #104 added an instrumentation.ts pre-warm:
```js
wa.ensureConnected({ timeoutMs: 30_000 }).then(...)
```
which races with the existing `autoRestoreSession()` module-load side effect inside `whatsapp-client.js`. Both paths call `initializeClient()` before either has finished `buildSock()`. The existing guard inside `initializeClient`:
```js
const existing = getState().sock;
if (existing) return existing;
```
misses (no socket has been assigned yet — `buildSock()` is still resolving), so both callers proceed to build a socket. Two sockets log in with the same `.baileys_auth/` creds, WhatsApp's MD protocol picks the latest and evicts the previous with `conflict: replaced`. Our connection-close handler then auto-reconnects on the eviction, restarting the fight.

## Fix

Two changes, both in `app/utils/whatsapp-client.js`:

1. **In-flight guard on `initializeClient`.** Concurrent callers now share one Promise via `globalAny.baileysInitInFlight`; exactly one `buildSock` runs per init cycle. Cleared in `finally` so a failed init still allows a future retry.

2. **Skip auto-reconnect on `DisconnectReason.connectionReplaced` (HTTP 440).** Even with #1 in place, a duplicate container, a stale process, or a dev box pointing at the same auth dir could cause a replace. Reconnecting just restarts the conflict loop; surface it to the operator (kill the duplicate, or scan a fresh QR).

## Coverage

- **New test** (`coalesces concurrent initializeClient() calls into one socket`): fires three concurrent `initializeClient()` calls, asserts `makeWASocket` called exactly once and all three callers receive the same socket reference.
- **New test** (`does NOT auto-reconnect on a connectionReplaced close`): emits a 440-coded close, waits past the 2s backoff, asserts no rebuild.
- 738/738 tests pass on the branch (was 736 — +2 new).

## Risk

Low. The in-flight guard is a strict tightening — any call site that worked before still works. The `connectionReplaced` skip changes behavior only for that specific Baileys disconnect code (which previously caused the fight loop, so no regression possible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)