### PR TITLE
fix: widen vendor_credentials encrypted columns to TEXT (closes #88)

### DIFF
--- a/app/migrations/016_widen_credential_columns.sql
+++ b/app/migrations/016_widen_credential_columns.sql
@@ -1,0 +1,57 @@
+-- Migration: widen the encrypted credential columns from VARCHAR(100) to TEXT.
+--
+-- Issue #88: long credit-card login emails (e.g. "user.name@long-domain.com")
+-- triggered an internal server error. Root cause: vendor_credentials.username
+-- was VARCHAR(100), but the encrypted form is `IV(24-hex):cipher(2*N hex):tag(32-hex)`
+-- with two `:` separators — so a 23-byte plaintext expands to 24 + 1 + 46 + 1 + 32 = 104
+-- characters. Anything longer than ~16 plaintext characters overflows the column,
+-- Postgres returns `value too long for type character varying(100)`, and the API
+-- bubbles a 500.
+--
+-- The same latent overflow exists on every encrypted column declared in
+-- 001_init_schema.sql. We widen them all here. TEXT in PostgreSQL has no
+-- length limit and is a strict superset of VARCHAR(100) — existing data is
+-- preserved untouched and no application code needs to change.
+--
+-- Idempotent: ALTER COLUMN ... TYPE TEXT is a no-op when the column is already
+-- TEXT, but we guard with information_schema checks anyway so the migration
+-- can be re-run safely against partially-migrated databases.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'vendor_credentials'
+      AND column_name = 'username'
+      AND data_type = 'character varying'
+  ) THEN
+    ALTER TABLE vendor_credentials ALTER COLUMN username TYPE TEXT;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'vendor_credentials'
+      AND column_name = 'password'
+      AND data_type = 'character varying'
+  ) THEN
+    ALTER TABLE vendor_credentials ALTER COLUMN password TYPE TEXT;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'vendor_credentials'
+      AND column_name = 'id_number'
+      AND data_type = 'character varying'
+  ) THEN
+    ALTER TABLE vendor_credentials ALTER COLUMN id_number TYPE TEXT;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'vendor_credentials'
+      AND column_name = 'card6_digits'
+      AND data_type = 'character varying'
+  ) THEN
+    ALTER TABLE vendor_credentials ALTER COLUMN card6_digits TYPE TEXT;
+  END IF;
+END $$;


### PR DESCRIPTION
Closes #88

## What

Migration `016_widen_credential_columns.sql` widens the four legacy encrypted columns on `vendor_credentials` from `VARCHAR(100)` → `TEXT`:

- `username`
- `password`
- `id_number`
- `card6_digits`

## Why

The encrypted form is `IV(24 hex):cipher(2*N hex):tag(32 hex)` where N is the plaintext byte length. A 23-byte plaintext (e.g. an email like \"user.name@long-domain.com\") encrypts to 104 characters — overflows `VARCHAR(100)`, Postgres returns *value too long for type character varying(100)*, and the API bubbles a 500. That's the *Internal server error* the user reported on Max credit-card login (#88).

`phone_number` and `otp_long_term_token` (added later in `011_onezero_2fa.sql`) were already `TEXT` and are not affected. Non-encrypted columns (`nickname`, `bank_account_number`, `vendor`) stay as-is.

## Notes

`TEXT` is a strict superset of `VARCHAR(100)` in PostgreSQL, so existing rows are preserved untouched. Idempotent via `information_schema` guards — the migration is safe to re-run on partially-migrated databases.

## Test plan

- [x] `npm run test` — 738/738 passing (unit suite doesn't hit the migration; included as a sanity check)
- [ ] After deploy: try logging into Max with the email format the user reported. Should succeed instead of 500ing.
- [ ] Existing accounts (already-saved short usernames) still load + sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)