### PR TITLE
fix(insights): wave 1 — kill the biggest false-positive sources

### DIFF
--- a/app/tests/anomaly_evaluate.test.ts
+++ b/app/tests/anomaly_evaluate.test.ts
@@ -49,6 +49,8 @@ describe('evaluateAnomalies', () => {
     it('detects a price hike, persists it, and reports inserted=1', async () => {
         const txs = buildPriceHikeTransactions();
         mockClient.query
+            // SELECT user-feedback labels (normal/dismissed) — none yet
+            .mockResolvedValueOnce({ rows: [] })
             // SELECT transactions
             .mockResolvedValueOnce({ rows: txs })
             // INSERT result for the price-hike row
@@ -72,6 +74,8 @@ describe('evaluateAnomalies', () => {
     it('reports updated (not inserted) when the same fingerprint already exists', async () => {
         const txs = buildPriceHikeTransactions();
         mockClient.query
+            // SELECT user-feedback labels — none.
+            .mockResolvedValueOnce({ rows: [] })
             .mockResolvedValueOnce({ rows: txs })
             // The xmax=0 trick returns false when the row was UPDATEd, true when INSERTed.
             .mockResolvedValueOnce({ rows: [{ was_inserted: false }] });
@@ -84,7 +88,11 @@ describe('evaluateAnomalies', () => {
 
     it('returns 0 detected when there is nothing notable in the data', async () => {
         // Empty transaction list — no patterns to detect.
-        mockClient.query.mockResolvedValueOnce({ rows: [] });
+        mockClient.query
+            // SELECT user-feedback labels — none.
+            .mockResolvedValueOnce({ rows: [] })
+            // SELECT transactions
+            .mockResolvedValueOnce({ rows: [] });
 
         const summary = await evaluateAnomalies();
 
@@ -98,5 +106,56 @@ describe('evaluateAnomalies', () => {
 
         await expect(evaluateAnomalies()).rejects.toThrow('boom');
         expect(mockClient.release).toHaveBeenCalled();
+    });
+
+    it('suppresses re-fires for merchants the user has marked normal', async () => {
+        // The detector finds a price hike on Apple Music exactly as before,
+        // but the user has previously labelled the same merchant `normal` —
+        // so the row should be suppressed (not inserted, not updated).
+        const txs = buildPriceHikeTransactions();
+        mockClient.query
+            // SELECT user-feedback labels — Apple Music is marked normal.
+            .mockResolvedValueOnce({
+                rows: [{
+                    type: 'price_hike',
+                    payload: { merchant: 'Apple Music', accountNumber: '1234' },
+                    status: 'normal',
+                    dismissed_at: null,
+                }],
+            })
+            .mockResolvedValueOnce({ rows: txs });
+
+        const summary = await evaluateAnomalies();
+
+        expect(summary.detected).toBe(1);
+        expect(summary.inserted).toBe(0);
+        expect(summary.updated).toBe(0);
+        expect(summary.suppressed).toBe(1);
+        // Critically: NO INSERT call should have been made.
+        const insertCalls = mockClient.query.mock.calls.filter((c: any[]) =>
+            String(c[0]).includes('INSERT INTO anomalies'),
+        );
+        expect(insertCalls).toHaveLength(0);
+    });
+
+    it('expires `dismissed` suppression after the 60-day window', async () => {
+        const txs = buildPriceHikeTransactions();
+        // Dismissed 90 days ago — past the 60-day window, should re-fire.
+        const longAgo = new Date(Date.now() - 90 * 86400 * 1000).toISOString();
+        mockClient.query
+            .mockResolvedValueOnce({
+                rows: [{
+                    type: 'price_hike',
+                    payload: { merchant: 'Apple Music', accountNumber: '1234' },
+                    status: 'dismissed',
+                    dismissed_at: longAgo,
+                }],
+            })
+            .mockResolvedValueOnce({ rows: txs })
+            .mockResolvedValueOnce({ rows: [{ was_inserted: true }] });
+
+        const summary = await evaluateAnomalies();
+        expect(summary.inserted).toBe(1);
+        expect(summary.suppressed).toBe(0);
     });
 });

--- a/app/tests/anomaly_normalize.test.ts
+++ b/app/tests/anomaly_normalize.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeMerchant } from '../utils/anomaly/normalize';
+
+describe('normalizeMerchant', () => {
+    it('lowercases, trims, and collapses internal whitespace', () => {
+        expect(normalizeMerchant('  Apple   Music  ')).toBe('apple music');
+        expect(normalizeMerchant('NETFLIX')).toBe('netflix');
+    });
+
+    it('strips trailing reference digits', () => {
+        // Common Israeli card-processor pattern: merchant name + ref number.
+        expect(normalizeMerchant('NETFLIX 1234')).toBe('netflix');
+        expect(normalizeMerchant('AMAZON 7XK1234')).toBe('amazon');
+    });
+
+    it('strips processor prefixes (PAYPAL, SQ, SP)', () => {
+        expect(normalizeMerchant('PAYPAL *SPOTIFY')).toBe('spotify');
+        expect(normalizeMerchant('SQ *Local Coffee')).toBe('local coffee');
+        expect(normalizeMerchant('SP *Stripe Inc')).toBe('stripe inc');
+    });
+
+    it('strips TLD-style suffixes', () => {
+        expect(normalizeMerchant('NETFLIX.COM')).toBe('netflix');
+        expect(normalizeMerchant('cibus.co.il')).toBe('cibus');
+    });
+
+    it('collapses split-merchant variants to the same key', () => {
+        // The whole point: the two split variants should map to one key
+        // so anomaly fingerprints collapse on UPSERT.
+        const a = normalizeMerchant('NETFLIX.COM');
+        const b = normalizeMerchant('NETFLIX 1234');
+        const c = normalizeMerchant('netflix');
+        expect(a).toBe(c);
+        expect(b).toBe(c);
+    });
+
+    it('is defensive against empty / non-string input', () => {
+        expect(normalizeMerchant('')).toBe('');
+        expect(normalizeMerchant(null)).toBe('');
+        expect(normalizeMerchant(undefined)).toBe('');
+    });
+
+    it('preserves merchants without trailing junk', () => {
+        // Don't over-strip — short word-only names keep their identity.
+        expect(normalizeMerchant('IKEA')).toBe('ikea');
+        expect(normalizeMerchant('Apple Music')).toBe('apple music');
+    });
+
+    it('strips trailing punctuation that survives the other passes', () => {
+        expect(normalizeMerchant('Spotify *')).toBe('spotify');
+        expect(normalizeMerchant('Some Merchant -')).toBe('some merchant');
+    });
+});

--- a/app/utils/anomaly/detectors/categorySpike.ts
+++ b/app/utils/anomaly/detectors/categorySpike.ts
@@ -80,7 +80,12 @@ export function detectCategorySpikes(
             .slice(0, 12)                            // trailing 12 weeks
             .map(([, v]) => v.spend);
 
-        if (priors.length < MIN_NONZERO_WEEKS) continue;
+        // The constant is named MIN_NONZERO_WEEKS but the original code
+        // counted the bucket count, including ₪0 weeks. That made one ₪500
+        // charge in a category with 11 silent weeks "spike" trivially.
+        // Filter to weeks with actual spend so the baseline is meaningful.
+        const nonZeroPriors = priors.filter((v) => v > 0);
+        if (nonZeroPriors.length < MIN_NONZERO_WEEKS) continue;
 
         const mean = priors.reduce((s, v) => s + v, 0) / priors.length;
         if (mean <= 0) continue;

--- a/app/utils/anomaly/detectors/newRecurring.ts
+++ b/app/utils/anomaly/detectors/newRecurring.ts
@@ -1,5 +1,6 @@
 import type { DetectedAnomaly } from '../types';
 import type { DetectedRecurringPayment } from '../../recurringDetection';
+import { normalizeMerchant } from '../normalize';
 
 /**
  * Flag newly-formed recurring patterns — the "you have a new subscription"
@@ -67,6 +68,3 @@ export function detectNewRecurring(recurring: DetectedRecurringPayment[]): Detec
     return out;
 }
 
-function normalizeMerchant(name: string): string {
-    return name.toLowerCase().trim().replace(/\s+/g, ' ');
-}

--- a/app/utils/anomaly/detectors/priceHike.ts
+++ b/app/utils/anomaly/detectors/priceHike.ts
@@ -1,4 +1,5 @@
 import type { DetectedAnomaly } from '../types';
+import { normalizeMerchant } from '../normalize';
 
 /**
  * Flag price hikes on established recurring-style merchants.
@@ -155,8 +156,4 @@ function findStableHistoryMean(
 
 function toMs(d: Date | string): number {
     return d instanceof Date ? d.getTime() : new Date(d).getTime();
-}
-
-function normalizeMerchant(name: string): string {
-    return name.toLowerCase().trim().replace(/\s+/g, ' ');
 }

--- a/app/utils/anomaly/evaluate.js
+++ b/app/utils/anomaly/evaluate.js
@@ -4,6 +4,69 @@ import { detectRecurringPayments } from '../recurringDetection';
 import { detectPriceHikes } from './detectors/priceHike';
 import { detectNewRecurring } from './detectors/newRecurring';
 import { detectCategorySpikes } from './detectors/categorySpike';
+import { normalizeMerchant } from './normalize';
+
+// User-feedback suppression windows. The schema's status column has four
+// values; only `normal` and `dismissed` mean "the user has seen this and
+// signalled how to handle it." We honor both, with different durations:
+//   normal     = "this is fine" — permanent suppression (the user
+//                explicitly told us this isn't anomalous; respect that
+//                until they manually re-open the row).
+//   dismissed  = "I closed this" — soft 60-day suppression (probably just
+//                inbox-clearing; OK to re-fire after that).
+const DISMISSED_SUPPRESSION_DAYS = 60;
+
+/**
+ * Build the semantic key a user is implicitly labelling when they action
+ * an anomaly. Distinct from the row's fingerprint (which is event-specific
+ * and changes month-to-month) — this is what the *underlying merchant /
+ * category* is, so we can match a labelled row from August against a fresh
+ * detection in November.
+ */
+function semanticKey(type, payload) {
+    if (!payload) return null;
+    if (type === 'price_hike' || type === 'new_recurring') {
+        const merchant = normalizeMerchant(payload.merchant);
+        if (!merchant) return null;
+        const account = payload.accountNumber ?? 'na';
+        return `${type}|${merchant}|${account}`;
+    }
+    if (type === 'category_spike') {
+        const cat = (payload.category ?? '').toString().toLowerCase().trim();
+        if (!cat) return null;
+        return `${type}|${cat}`;
+    }
+    return null;
+}
+
+/**
+ * Pull every anomaly the user has labelled (normal/dismissed), bucketed by
+ * semantic key + status. Detectors consult these buckets before inserting
+ * to suppress repeat fires. Without this, the user could click "this is
+ * normal" on an Apple iCloud price hike every month forever — the fingerprint
+ * changes (different monthKey) and we'd happily refire.
+ */
+async function loadUserFeedback(client) {
+    const result = await client.query(`
+        SELECT type, payload, status, dismissed_at
+        FROM anomalies
+        WHERE status IN ('normal', 'dismissed')
+    `);
+    const normalKeys = new Set();
+    const dismissedKeys = new Set();
+    const suppressionCutoff = Date.now() - DISMISSED_SUPPRESSION_DAYS * 86400 * 1000;
+    for (const row of result.rows) {
+        const key = semanticKey(row.type, row.payload);
+        if (!key) continue;
+        if (row.status === 'normal') {
+            normalKeys.add(key);
+        } else if (row.status === 'dismissed') {
+            const ts = row.dismissed_at ? new Date(row.dismissed_at).getTime() : 0;
+            if (ts >= suppressionCutoff) dismissedKeys.add(key);
+        }
+    }
+    return { normalKeys, dismissedKeys };
+}
 
 /**
  * Run every detector against the latest transaction history and UPSERT the
@@ -18,16 +81,19 @@ export async function evaluateAnomalies() {
     const client = await getDB();
     let inserted = 0;
     let updated = 0;
+    let suppressed = 0;
     const detected = [];
 
     try {
+        const feedback = await loadUserFeedback(client);
         // Pull a window of transactions wide enough for each detector:
         //  - priceHike + newRecurring need ~6 months of recurring history
         //  - categorySpike needs trailing 12 weeks
         // 270 days covers both with a comfortable margin.
         const txResult = await client.query(`
             SELECT identifier, vendor, name, price, category, account_number,
-                   date, processed_date, transaction_type
+                   date, processed_date, transaction_type,
+                   installments_number, installments_total
             FROM transactions
             WHERE date >= CURRENT_DATE - INTERVAL '270 days'
         `);
@@ -41,6 +107,8 @@ export async function evaluateAnomalies() {
             date: r.date,
             processed_date: r.processed_date,
             transaction_type: r.transaction_type,
+            installments_number: r.installments_number,
+            installments_total: r.installments_total,
         }));
 
         // priceHike runs directly on the transaction stream so it can see
@@ -63,7 +131,16 @@ export async function evaluateAnomalies() {
         const hikedMerchants = new Set(
             priceHikes.map((a) => `${(a.payload.merchant || '').toString().toLowerCase().trim()}|${a.payload.accountNumber ?? 'na'}`),
         );
-        const recurring = detectRecurringPayments(transactions);
+        // Strip Israeli installment-plan charges (תשלומים) before clustering.
+        // A fridge bought in 6 monthly installments has the same amount each
+        // month and looks like a fresh ₪200/mo subscription by month 2 — but
+        // it's bounded and the user already knows about it. We keep them in
+        // the priceHike + categorySpike paths because their amounts are
+        // legitimately part of those signals.
+        const nonInstallmentTx = transactions.filter(
+            (t) => !t.installments_total || Number(t.installments_total) <= 1,
+        );
+        const recurring = detectRecurringPayments(nonInstallmentTx);
         for (const a of detectNewRecurring(recurring)) {
             const key = `${(a.payload.merchant || '').toString().toLowerCase().trim()}|${a.payload.accountNumber ?? 'na'}`;
             if (hikedMerchants.has(key)) continue;
@@ -75,6 +152,16 @@ export async function evaluateAnomalies() {
         ));
 
         for (const a of detected) {
+            // Honor the user-feedback signal. Without this gate, the same
+            // merchant the user has marked "this is normal" gets re-flagged
+            // every month with a fresh fingerprint — the single biggest
+            // reason Insights felt dumb before.
+            const key = semanticKey(a.type, a.payload);
+            if (key && (feedback.normalKeys.has(key) || feedback.dismissedKeys.has(key))) {
+                suppressed++;
+                continue;
+            }
+
             const result = await client.query(
                 `INSERT INTO anomalies (type, severity, fingerprint, title, body, payload, related_transaction_keys, status)
                  VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, 'open')
@@ -100,10 +187,10 @@ export async function evaluateAnomalies() {
         }
 
         logger.info(
-            { detected: detected.length, inserted, updated },
+            { detected: detected.length, inserted, updated, suppressed },
             '[anomalies] Evaluation complete',
         );
-        return { detected: detected.length, inserted, updated };
+        return { detected: detected.length, inserted, updated, suppressed };
     } catch (err) {
         logger.error({ err: err.message }, '[anomalies] Evaluation failed');
         throw err;

--- a/app/utils/anomaly/normalize.ts
+++ b/app/utils/anomaly/normalize.ts
@@ -1,0 +1,69 @@
+/**
+ * Stricter merchant-name normalization for anomaly fingerprints + user-feedback
+ * matching. The detectors used to do `lowercase + trim + collapse-whitespace`
+ * only, which left them vulnerable to merchant-name drift very common with
+ * Israeli card processors:
+ *
+ *   "NETFLIX.COM"       vs "NETFLIX 1234"        → split into 2 clusters
+ *   "PAYPAL *SPOTIFY"   vs "PAYPAL *NYTIMES"     → kept distinct (good)
+ *   "AMAZON 7XK1234"    vs "AMAZON 7XK5678"      → 2 different "merchants"
+ *
+ * The split made one recurring sub look like two — and the second one would
+ * fire `new_recurring` even though it's the same charge under a slightly
+ * different reference number.
+ *
+ * Scope: this normalizer lives in the anomaly module specifically, NOT in
+ * recurringDetection.ts. recurringDetection feeds projection + recurring-
+ * payments reports too; changing its clustering would shift those screens
+ * unpredictably. Anomaly fingerprints can be tightened in isolation —
+ * collisions on UPSERT collapse split-detections into a single row, which
+ * is what the user actually sees.
+ */
+
+const PROCESSOR_PREFIXES = [
+    /^paypal\s*[*:]\s*/,    // "PAYPAL *", "PAYPAL: "
+    /^sq\s*[*:]\s*/,        // "SQ *" (Square)
+    /^sp\s*[*:]\s*/,        // "SP *" (Stripe)
+    /^pp\s*[*:]\s*/,        // "PP *"
+    /^עסק[ \t]+/,           // "עסק " (Hebrew "business" — common processor prefix)
+];
+
+const TLD_SUFFIXES = [
+    /\.co\.il\b.*$/,
+    /\.com\b.*$/,
+    /\.net\b.*$/,
+];
+
+/**
+ * Normalize a merchant string for keying. Idempotent. Defensive against
+ * empty / non-string input — callers don't need to pre-validate.
+ */
+export function normalizeMerchant(name: string | null | undefined): string {
+    if (typeof name !== 'string') return '';
+    let s = name.toLowerCase().trim().replace(/\s+/g, ' ');
+    if (!s) return '';
+
+    // Strip a known processor prefix (PAYPAL *FOO → "foo"). Loop in case of
+    // double-wrapped strings ("PP * PAYPAL *FOO"); rare but cheap to handle.
+    for (let i = 0; i < 2; i++) {
+        const before = s;
+        for (const re of PROCESSOR_PREFIXES) s = s.replace(re, '');
+        if (s === before) break;
+    }
+
+    // Strip TLD suffixes ("netflix.com — billing dept" → "netflix").
+    for (const re of TLD_SUFFIXES) s = s.replace(re, '');
+
+    // Drop trailing reference tokens that processors sprinkle on the end:
+    //   "amazon 7xk1234" → "amazon"
+    //   "netflix 12345"  → "netflix"
+    // The pattern requires the trailing token to include at least one digit
+    // (otherwise we'd strip the genuine last word of names like
+    // "Apple Music"). 3+ alphanumeric chars, optionally preceded by `#`/`-`.
+    s = s.replace(/\s+[#-]?(?=[0-9a-z]*\d)[0-9a-z]{3,}$/i, '');
+
+    // Drop trailing punctuation that survives the above.
+    s = s.replace(/[.,*\-_:#\s]+$/g, '').trim();
+
+    return s;
+}

--- a/app/utils/anomaly/summaryFragment.js
+++ b/app/utils/anomaly/summaryFragment.js
@@ -12,6 +12,13 @@ import logger from '../logger.js';
  * Why high+medium only, not low: low severity exists for the in-app inbox
  * (where the user opts into seeing them) but doesn't earn a WhatsApp
  * interruption. The bar for buzzing someone's phone is higher.
+ *
+ * Why filter on `updated_at`, not `created_at`: the evaluator UPSERTs on
+ * fingerprint and only bumps `updated_at` when re-flagging an existing row.
+ * If we filtered on `created_at`, an anomaly that fired Monday and the user
+ * left open through Wednesday would silently disappear from Tuesday's and
+ * Wednesday's digests — even though the underlying problem is still there.
+ * `updated_at` keeps the user reminded until they explicitly action it.
  */
 export async function getAnomalyPreambleForSummary({ getDB } = {}) {
     const dbModule = getDB ? null : await import('../../pages/api/db');
@@ -20,14 +27,14 @@ export async function getAnomalyPreambleForSummary({ getDB } = {}) {
 
     try {
         const result = await client.query(
-            `SELECT type, severity, title, payload, created_at
+            `SELECT type, severity, title, payload, updated_at
              FROM anomalies
              WHERE status = 'open'
                AND severity IN ('high', 'medium')
-               AND created_at >= NOW() - INTERVAL '24 hours'
+               AND updated_at >= NOW() - INTERVAL '24 hours'
              ORDER BY
                 CASE severity WHEN 'high' THEN 0 WHEN 'medium' THEN 1 ELSE 2 END,
-                created_at DESC
+                updated_at DESC
              LIMIT 5`,
         );
 


### PR DESCRIPTION
## Summary

Five focused fixes after the research pass on the anomaly detectors. Each one targets a real bug or a real false-positive vector found in the code; none of them rewrites the underlying detector heuristics. Together they should noticeably cut the Insights noise.

## What's in here

1. **Honor user feedback (`status='normal'` / `'dismissed'`) in detectors.** The schema and migration comments promised these signals would suppress repeat fires; nothing actually consumed them. When you marked an Apple Music renewal *\"normal\"*, next month's evaluator would happily re-flag it under a new fingerprint (the monthKey is part of `price_hike`'s fingerprint, so every month's hike was a fresh row). The evaluator now loads labelled rows up front, derives a stable semantic key (type + normalized merchant + account, or type + category for spikes), and skips matching detections. **`normal` = permanent; `dismissed` = 60-day soft suppression.** \"`suppressed`\" is now part of the evaluator's summary. *This is the highest-leverage change in the PR.*
2. **Fix `MIN_NONZERO_WEEKS` to actually filter non-zero weeks.** `categorySpike.ts:83` checked `priors.length`, not the count of weeks with spend. The constant name and source comment both said *\"non-zero weeks\"* — the code wasn't doing it. A category with one ₪500 charge in a quiet quarter trivially \"spiked\". Now `priors.filter(p > 0).length`.
3. **Exclude Israeli installment plans (תשלומים) from `new_recurring`.** A fridge bought in 6 monthly installments looks like a fresh ₪200/mo subscription by month 2. Filter `installments_total > 1` out of the recurring-detection input feeding `new_recurring`. The transactions stay in the priceHike + categorySpike paths, where their amounts are legitimate signal.
4. **Stricter merchant normalization for fingerprints.** New shared `normalize.ts` collapses Israeli-card-processor noise: \"NETFLIX.COM\" / \"NETFLIX 1234\" / \"PAYPAL *SPOTIFY\" / \"AMAZON 7XK1234\" all map to one key. Used inside priceHike and new_recurring fingerprints only — deliberately not in `recurringDetection.ts` (that powers the projection + recurring-payments screens too; changing its clustering is bigger scope). Fingerprint collisions on UPSERT collapse split-detect rows into one card, which is what the user actually sees.
5. **Switch the daily-digest window from `created_at` to `updated_at`.** The evaluator UPSERTs by fingerprint and only bumps `updated_at` on re-flagging. The WhatsApp/Telegram digest's `created_at` filter therefore silently dropped re-detections — a hike that fired Monday and stayed open through Wednesday never appeared in Tue/Wed digests, even though the underlying problem persisted.

## Tests

- 748/748 passing (was 738 — added 8 for the normalizer + 2 for the feedback-loop suppression).
- The evaluator test was tightened to mock the new \"load user feedback\" query at the top of each scenario.

## Explicitly out of scope

- priceHike's mean→median rewrite (its own PR — behavior change worth reviewing in isolation).
- Real-time push alerts on new high-severity anomalies (re-evaluate noise-floor once Wave 1 lands).
- UI affordance to un-suppress a `normal`-labelled row. Today you'd flip the row's status back to `open` via the existing `PATCH /api/anomalies/[id]` if you wanted to re-engage.

## Test plan

- [x] `npm run test` — 748/748
- [x] `npm run build` — implicit; no schema changes
- [ ] After deploy: mark a recurring price-hike card as \"normal\" / \"dismiss\". Run `/api/anomalies` POST to re-evaluate. Card should not reappear (suppressed).
- [ ] Confirm a previously-dismissed card from >60 days ago re-fires (the test asserts this, worth a smoke check).
- [ ] Confirm an installment-plan transaction stops appearing as a \"new subscription\" card.
- [ ] Confirm WhatsApp digest still surfaces yesterday's high-severity anomaly today (re-detected, `updated_at` fresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)