### PR TITLE
fix(insights): wave 2 — priceHike uses median + requires distinct months

### DIFF
--- a/app/tests/anomaly_priceHike.test.ts
+++ b/app/tests/anomaly_priceHike.test.ts
@@ -124,4 +124,51 @@ describe('detectPriceHikes', () => {
         // The refund is dropped, leaving 3 stable priors with no candidate latest.
         expect(detectPriceHikes(txs)).toEqual([]);
     });
+
+    it('still flags a real hike when one earlier prior is a one-off outlier', () => {
+        // The Wave 2 case: an out-of-band ₪200 charge in a stream of ₪19.90
+        // monthly charges used to corrupt the running mean and either reject
+        // a legitimate hike candidate or accept the outlier into the plateau.
+        // With median, the outlier is dampened and the real plateau wins.
+        const txs = [
+            tx('2026-05-15', 'Apple Music', -29.9),   // hike (latest)
+            tx('2026-04-15', 'Apple Music', -19.9),
+            tx('2026-03-15', 'Apple Music', -200),    // one-off (outlier)
+            tx('2026-02-15', 'Apple Music', -19.9),
+            tx('2026-01-15', 'Apple Music', -19.9),
+            tx('2025-12-15', 'Apple Music', -19.9),
+        ];
+        const out = detectPriceHikes(txs);
+        expect(out).toHaveLength(1);
+        // The plateau median should be ₪19.90, not pulled toward ₪200.
+        expect(out[0].payload.priorAverage).toBeCloseTo(19.9, 2);
+    });
+
+    it('does NOT flag when 3 stable priors all live in the same month', () => {
+        // 3 charges of ₪50 from the same merchant in February alone don't
+        // make a plateau — they could be 3 ad-hoc orders. New rule: the
+        // plateau has to span ≥3 distinct calendar months.
+        const txs = [
+            tx('2026-04-15', 'SomeStore', -120),
+            tx('2026-02-25', 'SomeStore', -50),
+            tx('2026-02-15', 'SomeStore', -50),
+            tx('2026-02-05', 'SomeStore', -50),
+        ];
+        expect(detectPriceHikes(txs)).toEqual([]);
+    });
+
+    it('flags with the 10% tolerance band (slightly looser than the 8% prior algo)', () => {
+        // 110 vs 100 / 100 / 100 = 10% spread between priors. Old algo's
+        // 8% rejection on the second-prior comparison would reject the
+        // plateau; new algo's median + 10% tolerance accepts it.
+        const txs = [
+            tx('2026-04-15', 'Gym', -150),     // candidate (50% hike)
+            tx('2026-03-15', 'Gym', -110),
+            tx('2026-02-15', 'Gym', -100),
+            tx('2026-01-15', 'Gym', -100),
+        ];
+        const out = detectPriceHikes(txs);
+        expect(out).toHaveLength(1);
+        expect(out[0].severity).toBe('high');
+    });
 });

--- a/app/utils/anomaly/detectors/priceHike.ts
+++ b/app/utils/anomaly/detectors/priceHike.ts
@@ -14,21 +14,41 @@ import { normalizeMerchant } from '../normalize';
  *  - Group transactions by normalized merchant name + account.
  *  - Within each group, sort newest-first.
  *  - Require at least 4 charges and at least 3 of them tightly clustered
- *    on amount (the "stable history") within the last 6 months.
+ *    on amount (the "stable plateau") spanning ≥3 distinct calendar months.
  *  - The most recent charge becomes the candidate. If it's materially higher
- *    than the stable mean, flag it.
+ *    than the plateau's median, flag it.
+ *
+ * Why median instead of mean (was the prior-art): a single one-off purchase
+ * from the same merchant (e.g. a one-time ₪200 Amazon order in a stream of
+ * ₪50 charges) used to drag the running mean and either let an outlier into
+ * the plateau or break the walker prematurely. Median is robust to a single
+ * stray value at the same N. With the small windows we deal with (≥3),
+ * median is also functionally a "trimmed median" — at N=3 it's the middle
+ * value; at N=4 it's the mean of the two middle values. No need for separate
+ * trim logic.
+ *
+ * Why ≥3 distinct months: a merchant that drops 3 charges of the same
+ * amount inside a single month (some non-recurring service that happens to
+ * bill in chunks) shouldn't form a "plateau" the next month's normal charge
+ * gets compared against. The distinct-months guard keeps us honest about
+ * what "recurring" means.
  *
  * Tunable thresholds:
  *  - >= 15% jump AND >= ₪5 absolute (so ₪0.50 → ₪0.60 noise doesn't fire).
  *  - severity 'high' if the jump is >= 25%, otherwise 'medium'.
- *  - "Stable history" = ≥3 charges within 8% of each other.
+ *  - "Stable plateau" = ≥3 charges within 10% of the running median,
+ *    spanning ≥3 distinct calendar months.
  */
 
 const PRICE_HIKE_RELATIVE_THRESHOLD = 0.15;
 const PRICE_HIKE_ABSOLUTE_THRESHOLD = 5;
 const HIGH_SEVERITY_RELATIVE = 0.25;
-const STABLE_HISTORY_TOLERANCE = 0.08;
+// Slightly looser tolerance than the old 8%: median is more stable than
+// mean, so we can afford a wider band before declaring the plateau broken
+// without inviting false positives.
+const STABLE_HISTORY_TOLERANCE = 0.10;
 const MIN_STABLE_HISTORY = 3;
+const MIN_DISTINCT_MONTHS = 3;
 
 export interface PriceHikeTransaction {
     name: string;
@@ -66,14 +86,20 @@ export function detectPriceHikes(transactions: PriceHikeTransaction[]): Detected
         const latestAbs = Math.abs(latest.price);
 
         // Find the most recent run of "stable" prior charges (consecutive,
-        // within tolerance of each other). This guards against the case where
-        // history was already noisy — only call it a hike when there was a
-        // real plateau to hike from.
-        const stableMean = findStableHistoryMean(priors, MIN_STABLE_HISTORY, STABLE_HISTORY_TOLERANCE);
-        if (stableMean == null) continue;
+        // within tolerance of each other) spanning ≥ MIN_DISTINCT_MONTHS
+        // distinct calendar months. The plateau guard keeps us from flagging
+        // a hike when history was already noisy — there has to be a real
+        // baseline for the latest charge to deviate from.
+        const stableBaseline = findStableHistoryMedian(
+            priors,
+            MIN_STABLE_HISTORY,
+            MIN_DISTINCT_MONTHS,
+            STABLE_HISTORY_TOLERANCE,
+        );
+        if (stableBaseline == null) continue;
 
-        const diff = latestAbs - stableMean;
-        const relative = diff / stableMean;
+        const diff = latestAbs - stableBaseline;
+        const relative = diff / stableBaseline;
         if (relative < PRICE_HIKE_RELATIVE_THRESHOLD) continue;
         if (diff < PRICE_HIKE_ABSOLUTE_THRESHOLD) continue;
 
@@ -83,14 +109,14 @@ export function detectPriceHikes(transactions: PriceHikeTransaction[]): Detected
             'price_hike',
             normalizeMerchant(latest.name),
             latest.account_number ?? 'na',
-            stableMean.toFixed(2),
+            stableBaseline.toFixed(2),
             latestAbs.toFixed(2),
             monthKey,
         ].join('|');
 
         const severity = relative >= HIGH_SEVERITY_RELATIVE ? 'high' : 'medium';
         const pct = Math.round(relative * 100);
-        const fromIls = stableMean.toFixed(2).replace(/\.00$/, '');
+        const fromIls = stableBaseline.toFixed(2).replace(/\.00$/, '');
         const toIls = latestAbs.toFixed(2).replace(/\.00$/, '');
 
         out.push({
@@ -101,7 +127,10 @@ export function detectPriceHikes(transactions: PriceHikeTransaction[]): Detected
             body: `Recurring charge from ${latest.name} jumped ${pct}% — was ₪${fromIls} for several months, now ₪${toIls}.`,
             payload: {
                 merchant: latest.name,
-                priorAverage: Number(stableMean.toFixed(2)),
+                // Field name is preserved for back-compat with existing rows
+                // and the Telegram/WhatsApp digest formatter; the value is now
+                // the median, which is a more robust "typical" than the mean.
+                priorAverage: Number(stableBaseline.toFixed(2)),
                 newAmount: Number(latestAbs.toFixed(2)),
                 relativeChange: Number(relative.toFixed(4)),
                 accountNumber: latest.account_number ?? null,
@@ -116,42 +145,70 @@ export function detectPriceHikes(transactions: PriceHikeTransaction[]): Detected
 /**
  * Walk the prior-history (newest-first) looking for a consecutive run of
  * `minLength` charges whose amounts are all within `tolerance` of their
- * running mean. Returns that run's mean, or null if no such run exists.
+ * *running median* and which span at least `minMonths` distinct calendar
+ * months. Returns that run's median, or null if no such run exists.
  *
- * The point: only flag a hike when there's a real "plateau" the latest
- * charge departed from. If history is already chaotic (rent payments,
- * variable utility bills), we'd rather skip than false-positive.
+ * Why median (not mean): a single outlier in the early window — say one
+ * one-off ₪200 Amazon order in a stream of ₪50 monthly charges — used to
+ * drag the running mean and either reject the legitimate next charge or
+ * accept the outlier into the plateau. Median is robust to one weird
+ * value at every plateau size we ever build (≥3 charges).
+ *
+ * Why distinct-months: 3 charges from the same merchant inside a single
+ * calendar month don't represent a "stable monthly" plateau — they're
+ * just three charges. Requiring distinct months means the plateau has to
+ * actually look recurring.
  */
-function findStableHistoryMean(
+function findStableHistoryMedian(
     priors: PriceHikeTransaction[],
     minLength: number,
+    minMonths: number,
     tolerance: number,
 ): number | null {
     if (priors.length < minLength) return null;
-    const window: number[] = [];
+    const window: PriceHikeTransaction[] = [];
     for (const t of priors) {
         const a = Math.abs(t.price);
         if (window.length === 0) {
-            window.push(a);
+            window.push(t);
             continue;
         }
-        const mean = window.reduce((s, v) => s + v, 0) / window.length;
-        if (mean === 0) return null;
-        if (Math.abs(a - mean) / mean <= tolerance) {
-            window.push(a);
+        const med = median(window.map((w) => Math.abs(w.price)));
+        if (med === 0) return null;
+        if (Math.abs(a - med) / med <= tolerance) {
+            window.push(t);
             if (window.length >= minLength) {
-                // We found a stable plateau — return its mean rather than
-                // continuing to grow the window with potentially older
-                // less-stable data.
-                return window.reduce((s, v) => s + v, 0) / window.length;
+                const monthsSpanned = new Set(
+                    window.map((w) => monthKey(w.date)),
+                ).size;
+                if (monthsSpanned >= minMonths) {
+                    // Found a qualifying plateau — return its median.
+                    return median(window.map((w) => Math.abs(w.price)));
+                }
+                // Cluster size is right but not enough months yet — keep
+                // walking; an older same-amount charge from a different
+                // month may complete the requirement.
             }
         } else {
             // Plateau broken; restart from this point.
             window.length = 0;
-            window.push(a);
+            window.push(t);
         }
     }
     return null;
+}
+
+function median(nums: number[]): number {
+    if (nums.length === 0) return 0;
+    const sorted = nums.slice().sort((a, b) => a - b);
+    const mid = sorted.length >> 1;
+    if (sorted.length % 2 === 1) return sorted[mid];
+    return (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+function monthKey(d: Date | string): string {
+    const dt = d instanceof Date ? d : new Date(d);
+    return `${dt.getUTCFullYear()}-${String(dt.getUTCMonth() + 1).padStart(2, '0')}`;
 }
 
 function toMs(d: Date | string): number {


### PR DESCRIPTION
## What

Single-detector behavior change to `priceHike`, kept in its own PR so the heuristic shift is reviewable in isolation.

| Change | Before | After |
|---|---|---|
| Plateau anchor | running **mean** | running **median** |
| Tolerance | 8% | 10% |
| Plateau-size requirement | ≥3 | ≥3 (unchanged) |
| Distinct-months requirement | none | **≥3 distinct calendar months** |

## Why each change

**Mean → median.** The old greedy walker recomputed a *mean* at each step, so a single one-off charge in the prior history (e.g. one ₪200 Amazon order in a stream of ₪50 monthly charges) could drag the mean enough to either reject a real hike's candidate or accept the outlier into the plateau. Median is robust to a single stray value at every plateau size we ever build. At N=3 the median IS the trimmed median; at N=4 it's the mean of the two middle values, also identical to the median. No need for separate trim logic.

**8% → 10% tolerance.** Median is more stable than mean, so a slightly wider band still rejects noisy histories without inviting false positives. Specifically calibrated for the case where prior charges drift slightly (₪100, ₪110, ₪100, ₪100) and the old 8% would have rejected the plateau prematurely.

**≥3 distinct months requirement.** Three charges from the same merchant inside a single calendar month don't make a *stable monthly* plateau — they're just three ad-hoc charges. Without this guard, the next month's normal charge could look like a hike against a plateau that was never recurring to begin with.

## Compatibility

- `payload.priorAverage` field name preserved; value is now the median, not the mean. WhatsApp/Telegram digest formatters and the Insights UI keep working unchanged. The user-visible meaning is still \"the typical prior amount.\"
- Fingerprint shape unchanged. Fingerprints from old runs that match fresh ones (same merchant + account + monthKey + baseline-rounded-to-2dp) will UPSERT in place.

## Tests

- **10 existing priceHike tests** pass unchanged (their fixtures already span ≥3 distinct months and use uniform prior amounts, where median equals mean).
- **3 new tests:**
  - *\"still flags a real hike when one earlier prior is a one-off outlier\"* — the exact scenario the research flagged. Asserts `priorAverage` is the median (₪19.90), not pulled toward ₪200.
  - *\"does NOT flag when 3 stable priors all live in the same month\"* — asserts the new distinct-months guard.
  - *\"flags with the 10% tolerance band\"* — asserts the loosened tolerance still produces a plateau in cases the old 8% would have rejected.
- Full suite: **751/751** (was 748 + 3).

## Explicitly out of scope

- Quarterly subs still can't form a plateau here — by design; that's a separate detection problem.
- *\"Materially worse\"* override for `normal` suppression — would let a re-fire happen when an acknowledged hike has now jumped much further. Tracked as a Wave 3 candidate.

## Test plan

- [x] `npm run test` — 751/751
- [ ] After deploy: verify a flagged price hike from the previous algorithm either stays flagged (same fingerprint UPSERT) or, if it was a false positive (one-off outlier corruption), now does not re-fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)