### PR TITLE
fix(whatsapp): respect user-initiated disconnect

### DIFF
--- a/app/tests/whatsapp-client.test.ts
+++ b/app/tests/whatsapp-client.test.ts
@@ -83,6 +83,7 @@ function clearBaileysGlobals() {
     delete g.baileysEmitter;
     delete g.baileysAutoRestoreAttempted;
     delete g.baileysInitInFlight;
+    delete g.baileysIntentionalDisconnect;
     delete g.whatsappStatus;
 }
 
@@ -241,6 +242,33 @@ describe('whatsapp-client', () => {
         expect(mod.getClient()).toBeNull();
         expect(lastMockSock!.end).toHaveBeenCalled();
     });
+
+    it('destroyClient suppresses the auto-reconnect that the resulting close event would otherwise trigger', async () => {
+        // Regression: clicking "Disconnect" in settings called destroyClient,
+        // which closed the socket — but the resulting connection.update close
+        // event (statusCode neither 401 nor 440) fell through to the
+        // auto-reconnect path and the socket came right back ~2s later.
+        const mod = await import('../utils/whatsapp-client.js');
+        await mod.initializeClient();
+        lastMockSock!.ev.emit('connection.update', { connection: 'open' });
+        expect(makeWASocketMock).toHaveBeenCalledTimes(1);
+
+        const closedSock = lastMockSock!;
+        await mod.destroyClient();
+        // Simulate Baileys firing its `close` connection.update in response
+        // to sock.end() — this is what the real socket does.
+        closedSock.ev.emit('connection.update', {
+            connection: 'close',
+            lastDisconnect: { error: { output: { statusCode: 428 } } },
+        });
+
+        // Wait past the 2s auto-reconnect backoff plus padding. If the bug
+        // were still present, makeWASocketMock would have been called again.
+        await new Promise((r) => setTimeout(r, 2_500));
+        expect(makeWASocketMock).toHaveBeenCalledTimes(1);
+        expect(mod.getStatus().status).toBe('DISCONNECTED');
+        expect(mod.getClient()).toBeNull();
+    }, 10_000);
 
     it('waitForReady resolves immediately if status is already READY', async () => {
         const mod = await import('../utils/whatsapp-client.js');

--- a/app/utils/whatsapp-client.js
+++ b/app/utils/whatsapp-client.js
@@ -198,6 +198,18 @@ function wireSockEvents(sock) {
             setStatus('DISCONNECTED', { qr: null });
             emitter.emit('disconnected', { code, reason, loggedOut, replaced });
 
+            // User-initiated teardown (destroyClient) flips this flag before
+            // calling sock.end(). Without the guard, the resulting close event
+            // falls through to the auto-reconnect branch below and the socket
+            // pops right back up — the "Disconnect" button in settings appears
+            // to do nothing.
+            if (globalAny.baileysIntentionalDisconnect) {
+                logger.info('[baileys] Intentional disconnect — skipping auto-reconnect');
+                globalAny.baileysIntentionalDisconnect = false;
+                globalAny.baileysSock = null;
+                return;
+            }
+
             // On loggedOut, the saved session is dead — only a fresh QR scan
             // helps. Don't auto-reconnect (we'd just spin up another socket
             // and immediately get kicked again).
@@ -260,6 +272,11 @@ export async function initializeClient() {
     const hasSession = hasPersistedSession();
     logger.info({ hasPersistedSession: hasSession }, '[baileys] Initializing new client');
 
+    // Clear any leftover intentional-disconnect flag — caller wants a live
+    // connection, so future close events should be treated normally
+    // (auto-reconnect on transient drops, etc.).
+    globalAny.baileysIntentionalDisconnect = false;
+
     setStatus('INITIALIZING');
     globalAny.whatsappStatus = 'INITIALIZING';
 
@@ -285,7 +302,15 @@ export async function initializeClient() {
 
 export async function destroyClient() {
     const sock = getState().sock;
-    if (!sock) return;
+    // Set BEFORE sock.end() — the close event handler reads this synchronously
+    // when the WebSocket fires, and the reconnect-suppression check needs to
+    // see the flag already set.
+    globalAny.baileysIntentionalDisconnect = true;
+    if (!sock) {
+        setStatus('DISCONNECTED', { qr: null });
+        globalAny.whatsappStatus = 'DISCONNECTED';
+        return;
+    }
     try {
         // logout() actually logs the session out of WhatsApp servers — we
         // don't want that, just the local close. end() with no args is the


### PR DESCRIPTION
## Summary
- Clicking "Disconnect" in settings called `destroyClient()`, but the resulting `connection.update` close event (statusCode neither 401 nor 440) fell through to the auto-reconnect branch — the socket popped right back up ~2s later and the button appeared to do nothing.
- `destroyClient` now sets an intentional-disconnect flag before `sock.end()`; the close handler short-circuits when it sees the flag. `initializeClient` clears it so a subsequent connect/restart isn't sticky.

## Test plan
- [x] New regression test in `whatsapp-client.test.ts` simulates the close event Baileys fires after `destroyClient()` and asserts no second `makeWASocket` call after the 2s backoff
- [x] Existing whatsapp tests still pass (22/22)
- [ ] Manual: connect WhatsApp, click Disconnect in settings, confirm status stays DISCONNECTED

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4KQ4DadHSZVPxxEapF8Xb)_