### PR TITLE
fix(whatsapp): persist disconnect across reboots

### DIFF
--- a/app/pages/api/whatsapp/status.js
+++ b/app/pages/api/whatsapp/status.js
@@ -1,5 +1,5 @@
 
-import { getStatus, restartClient, destroyClient, initializeClient, renewQrCode } from '../../../utils/whatsapp-client.js';
+import { getStatus, restartClient, destroyClient, initializeClient, renewQrCode, clearSession } from '../../../utils/whatsapp-client.js';
 
 export default async function handler(req, res) {
     if (req.method === 'GET') {
@@ -22,7 +22,12 @@ export default async function handler(req, res) {
         }
 
         if (action === 'disconnect') {
+            // User-initiated disconnect must persist across reboots. destroyClient()
+            // only closes the socket and intentionally preserves creds on disk so
+            // restartClient()/renewQrCode() can reuse them; without clearSession()
+            // here, autoRestoreSession() rebuilds the connection on next boot.
             await destroyClient();
+            clearSession();
             return res.status(200).json({ message: 'Client disconnected' });
         }
 

--- a/app/tests/whatsapp-status-api.test.ts
+++ b/app/tests/whatsapp-status-api.test.ts
@@ -11,9 +11,10 @@ vi.mock('../utils/whatsapp-client.js', () => ({
     destroyClient: vi.fn().mockResolvedValue(undefined),
     initializeClient: vi.fn(),
     renewQrCode: vi.fn(),
+    clearSession: vi.fn().mockReturnValue(true),
 }));
 
-import { getStatus, restartClient, destroyClient, initializeClient, renewQrCode } from '../utils/whatsapp-client.js';
+import { getStatus, restartClient, destroyClient, initializeClient, renewQrCode, clearSession } from '../utils/whatsapp-client.js';
 
 // Helper to create mock req/res
 function createMockReqRes(method: string, body?: object) {
@@ -81,6 +82,21 @@ describe('WhatsApp Status API', () => {
             expect(destroyClient).toHaveBeenCalled();
             expect(res.status).toHaveBeenCalledWith(200);
             expect(res.json).toHaveBeenCalledWith({ message: 'Client disconnected' });
+        });
+
+        it('disconnect clears the persisted session so next boot does not auto-reconnect', async () => {
+            // Regression: without clearSession(), .baileys_auth/creds.json
+            // survives the disconnect and autoRestoreSession() rebuilds the
+            // connection on the next process start.
+            const { req, res } = createMockReqRes('POST', { action: 'disconnect' });
+
+            await handler(req as any, res as any);
+
+            expect(destroyClient).toHaveBeenCalled();
+            expect(clearSession).toHaveBeenCalled();
+            const destroyOrder = (destroyClient as any).mock.invocationCallOrder[0];
+            const clearOrder = (clearSession as any).mock.invocationCallOrder[0];
+            expect(destroyOrder).toBeLessThan(clearOrder);
         });
 
         it('should handle renewQr action', async () => {


### PR DESCRIPTION
## Summary
- Clicking "Disconnect Session" did not survive a restart: `destroyClient()` intentionally preserves `.baileys_auth/creds.json` so internal callers (`restartClient`, `renewQrCode`) can reuse the session, but the API `disconnect` action inherited that behavior. On next boot, `autoRestoreSession()` found the creds and silently reconnected.
- The `disconnect` API action now calls `clearSession()` after `destroyClient()`, so the on-disk auth state is wiped and the next boot starts cold.
- Internal callers are untouched; they still manage creds explicitly.

## Test plan
- [x] `npm test -- --run whatsapp-status-api whatsapp-client` — 22 passed (includes new regression test asserting `clearSession` is called after `destroyClient` on disconnect)
- [x] `npm run lint` — clean
- [ ] Manual: click "Disconnect Session", restart the app, confirm status is `DISCONNECTED` and no auto-reconnect occurs


---
_Generated by [Claude Code](https://claude.ai/code/session_013Fj3T6u24ZNyTxgdUqXVWG)_