### PR TITLE
refactor: reduce duplication and standardize opposite-pair patterns

### DIFF
--- a/app/components/AccountsModal.tsx
+++ b/app/components/AccountsModal.tsx
@@ -103,7 +103,7 @@ interface CardOwnership {
 }
 
 interface AccountsModalProps {
-  isOpen: boolean;
+  open: boolean;
   onClose: () => void;
 }
 
@@ -135,7 +135,7 @@ const AccountSection = styled(Box)(() => ({
   },
 }));
 
-export default function AccountsModal({ isOpen, onClose }: AccountsModalProps) {
+export default function AccountsModal({ open, onClose }: AccountsModalProps) {
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [cardOwnership, setCardOwnership] = useState<CardOwnership[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -198,12 +198,12 @@ export default function AccountsModal({ isOpen, onClose }: AccountsModalProps) {
   }, []);
 
   useEffect(() => {
-    if (!isOpen) return;
+    if (!open) return;
     queueMicrotask(() => {
       fetchAccounts();
       fetchCardOwnership();
     });
-  }, [isOpen, fetchAccounts, fetchCardOwnership]);
+  }, [open, fetchAccounts, fetchCardOwnership]);
 
   // Helper to get owned cards for a specific credential
   const getOwnedCards = (credentialId: number): CardOwnership[] => {
@@ -872,7 +872,7 @@ export default function AccountsModal({ isOpen, onClose }: AccountsModalProps) {
   return (
     <>
       <Dialog
-        open={isOpen}
+        open={open}
         onClose={() => {
           if (isAdding || isEditing) {
             handleCancelForm();
@@ -1130,7 +1130,7 @@ export default function AccountsModal({ isOpen, onClose }: AccountsModalProps) {
         </DialogContent>
       </Dialog>
       <ScrapeModal
-        isOpen={isScrapeModalOpen}
+        open={isScrapeModalOpen}
         onClose={() => {
           setIsScrapeModalOpen(false);
           setSelectedAccount(null);
@@ -1156,7 +1156,7 @@ export default function AccountsModal({ isOpen, onClose }: AccountsModalProps) {
         } : undefined}
       />
       <SyncHistoryModal
-        isOpen={isHistoryOpen}
+        open={isHistoryOpen}
         onClose={() => setIsHistoryOpen(false)}
       />
       {/* Truncate Confirmation Dialog */}

--- a/app/components/AccountsModal.tsx
+++ b/app/components/AccountsModal.tsx
@@ -941,7 +941,7 @@ export default function AccountsModal({ open, onClose }: AccountsModalProps) {
                 startIcon={<AddIcon />}
                 onClick={() => setIsAdding(true)}
                 sx={{
-                  backgroundColor: '#3b82f6',
+                  backgroundColor: 'var(--n-info)',
                   '&:hover': {
                     backgroundColor: '#2563eb',
                   },
@@ -977,7 +977,7 @@ export default function AccountsModal({ open, onClose }: AccountsModalProps) {
             </Box>
           ) : isAdding || isEditing ? (
             <Box sx={{ p: 2 }}>
-              <Typography variant="h6" sx={{ mb: 2, color: isEditing ? '#8b5cf6' : '#3b82f6' }}>
+              <Typography variant="h6" sx={{ mb: 2, color: isEditing ? '#8b5cf6' : 'var(--n-info)' }}>
                 {isEditing ? t('accounts.editAccount') : t('accounts.addAccountTitle')}
               </Typography>
               <TextField
@@ -1092,7 +1092,7 @@ export default function AccountsModal({ open, onClose }: AccountsModalProps) {
                   variant="contained"
                   onClick={isEditing ? handleUpdate : handleAdd}
                   sx={{
-                    backgroundColor: isEditing ? '#8b5cf6' : '#3b82f6',
+                    backgroundColor: isEditing ? '#8b5cf6' : 'var(--n-info)',
                     '&:hover': {
                       backgroundColor: isEditing ? '#7c3aed' : '#2563eb',
                     },
@@ -1107,7 +1107,7 @@ export default function AccountsModal({ open, onClose }: AccountsModalProps) {
               {/* Bank Accounts Section */}
               <AccountSection>
                 <SectionHeader>
-                  <AccountBalanceIcon sx={{ color: '#3b82f6', fontSize: '24px' }} />
+                  <AccountBalanceIcon sx={{ color: 'var(--n-info)', fontSize: '24px' }} />
                   <Typography variant="h6" color="primary">
                     {t('accounts.bankAccountsCount', { count: bankAccounts.length })}
                   </Typography>
@@ -1173,7 +1173,7 @@ export default function AccountsModal({ open, onClose }: AccountsModalProps) {
         }}
       >
         <DialogTitle sx={{
-          color: '#f59e0b',
+          color: 'var(--n-warning)',
           fontWeight: 600,
           display: 'flex',
           alignItems: 'center',
@@ -1191,7 +1191,7 @@ export default function AccountsModal({ open, onClose }: AccountsModalProps) {
               components={{ strong: <strong /> }}
             />
           </Typography>
-          <Typography variant="body2" sx={{ color: '#ef4444' }}>
+          <Typography variant="body2" sx={{ color: 'var(--n-error)' }}>
             {t('accounts.truncateWarning')}
           </Typography>
         </DialogContent>
@@ -1207,7 +1207,7 @@ export default function AccountsModal({ open, onClose }: AccountsModalProps) {
             variant="contained"
             disabled={isTruncating}
             sx={{
-              backgroundColor: '#f59e0b',
+              backgroundColor: 'var(--n-warning)',
               '&:hover': {
                 backgroundColor: '#d97706',
               },

--- a/app/components/AccountsView.tsx
+++ b/app/components/AccountsView.tsx
@@ -435,7 +435,7 @@ const AccountsView: React.FC = () => {
             </Container>
             {/* Sync History Modal */}
             <SyncHistoryModal
-                isOpen={isHistoryOpen}
+                open={isHistoryOpen}
                 onClose={() => setIsHistoryOpen(false)}
             />
             {/* Add/Edit Modal */}

--- a/app/components/BreakdownView.tsx
+++ b/app/components/BreakdownView.tsx
@@ -607,7 +607,7 @@ const BreakdownView: React.FC = () => {
                                                                     renderInput={(params) => <TextField {...params} autoFocus placeholder={t('breakdown.categoryPlaceholder')} />}
                                                                 />
                                                                 <IconButton size="small" onClick={() => handleCategorySave(row.description!)} sx={{ color: '#4ADE80' }}><CheckIcon /></IconButton>
-                                                                <IconButton size="small" onClick={handleCategoryCancel} sx={{ color: '#ef4444' }}><CloseIcon /></IconButton>
+                                                                <IconButton size="small" onClick={handleCategoryCancel} sx={{ color: 'var(--n-error)' }}><CloseIcon /></IconButton>
                                                             </Box>
                                                         ) : (
                                                             <span
@@ -617,7 +617,7 @@ const BreakdownView: React.FC = () => {
                                                                     borderRadius: '6px',
                                                                     fontSize: '13px',
                                                                     cursor: 'pointer',
-                                                                    color: '#3b82f6',
+                                                                    color: 'var(--n-info)',
                                                                     fontWeight: 500
                                                                 }}
                                                                 onClick={() => handleCategoryEditClick(row.description!, row.category || '')}
@@ -786,7 +786,7 @@ const BreakdownMobileCardContent = ({
                                 renderInput={(params) => <TextField {...params} autoFocus placeholder={t('breakdown.categoryPlaceholder')} />}
                             />
                             <IconButton size="small" onClick={() => handleCategorySave(row.description!)} sx={{ color: '#4ADE80' }}><CheckIcon fontSize="small" /></IconButton>
-                            <IconButton size="small" onClick={handleCategoryCancel} sx={{ color: '#ef4444' }}><CloseIcon fontSize="small" /></IconButton>
+                            <IconButton size="small" onClick={handleCategoryCancel} sx={{ color: 'var(--n-error)' }}><CloseIcon fontSize="small" /></IconButton>
                         </Box>
                     ) : (
                         <span
@@ -796,7 +796,7 @@ const BreakdownMobileCardContent = ({
                                 borderRadius: '6px',
                                 fontSize: '11px',
                                 cursor: 'pointer',
-                                color: '#3b82f6',
+                                color: 'var(--n-info)',
                                 fontWeight: 600
                             }}
                             onClick={() => handleCategoryEditClick(row.description!, row.category || '')}

--- a/app/components/BreakdownView.tsx
+++ b/app/components/BreakdownView.tsx
@@ -13,8 +13,6 @@ import {
     IconButton,
     TextField,
     Autocomplete,
-    Snackbar,
-    Alert,
     FormControlLabel,
     Switch,
     useMediaQuery
@@ -35,6 +33,8 @@ import { logger } from '../utils/client-logger';
 import { getTableHeaderCellStyle, getTableBodyCellStyle, TABLE_ROW_HOVER_STYLE, getTableRowHoverBackground } from './CategoryDashboard/utils/tableStyles';
 import MobileSortableTable from './MobileSortableTable';
 import { useTranslation } from 'react-i18next';
+import { useSnackbar } from './hooks/useSnackbar';
+import SnackbarFeedback from './SnackbarFeedback';
 
 // Maximum date range in years
 const MAX_YEARS_RANGE = 5;
@@ -98,11 +98,7 @@ const BreakdownView: React.FC = () => {
     const [loadingMore, setLoadingMore] = useState(false);
     const [_total, setTotal] = useState(0);
     const PAGE_SIZE = 50;
-    const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: 'success' | 'error' }>({
-        open: false,
-        message: '',
-        severity: 'success'
-    });
+    const { snackbar, showSnackbar, hideSnackbar } = useSnackbar();
 
     const validateDateRange = (start: string, end: string): boolean => {
         if (!start || !end) return false;
@@ -238,7 +234,7 @@ const BreakdownView: React.FC = () => {
 
     const handleCategorySave = async (description: string) => {
         if (!editCategory.trim()) {
-            setSnackbar({ open: true, message: t('breakdown.snackbarCategoryEmpty'), severity: 'error' });
+            showSnackbar(t('breakdown.snackbarCategoryEmpty'), 'error');
             return;
         }
 
@@ -265,13 +261,13 @@ const BreakdownView: React.FC = () => {
                 const message = result.transactionsUpdated > 1
                     ? t('breakdown.snackbarTransactionsUpdated', { count: result.transactionsUpdated })
                     : t('breakdown.snackbarCategoryUpdated');
-                setSnackbar({ open: true, message, severity: 'success' });
+                showSnackbar(message, 'success');
             } else {
-                setSnackbar({ open: true, message: t('breakdown.snackbarFailedUpdateCategory'), severity: 'error' });
+                showSnackbar(t('breakdown.snackbarFailedUpdateCategory'), 'error');
             }
         } catch (error) {
             logger.error('Error updating category', error);
-            setSnackbar({ open: true, message: t('breakdown.snackbarErrorUpdateCategory'), severity: 'error' });
+            showSnackbar(t('breakdown.snackbarErrorUpdateCategory'), 'error');
         }
         setEditingDescription(null);
     };
@@ -707,16 +703,13 @@ const BreakdownView: React.FC = () => {
                     currentMonth={dateRangeMode === "custom" ? `${customStartDate}` : `${selectedYear}-${selectedMonth}`}
                 />
             )}
-            <Snackbar
-                open={snackbar.open}
+            <SnackbarFeedback
+                snackbar={snackbar}
+                onClose={hideSnackbar}
                 autoHideDuration={5000}
-                onClose={() => setSnackbar({ ...snackbar, open: false })}
                 anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
-            >
-                <Alert onClose={() => setSnackbar({ ...snackbar, open: false })} severity={snackbar.severity} sx={{ width: "100%", borderRadius: "12px" }}>
-                    {snackbar.message}
-                </Alert>
-            </Snackbar>
+                alertSx={{ width: "100%", borderRadius: "12px" }}
+            />
         </Box>
     );
 };

--- a/app/components/CardVendorsModal.tsx
+++ b/app/components/CardVendorsModal.tsx
@@ -9,8 +9,6 @@ import {
   MenuItem,
   styled,
   Typography,
-  Snackbar,
-  Alert,
   useTheme,
   alpha
 } from '@mui/material';
@@ -19,6 +17,8 @@ import CreditCardIcon from '@mui/icons-material/CreditCard';
 import AccountBalanceIcon from '@mui/icons-material/AccountBalance';
 import ModalHeader from './ModalHeader';
 import { BANK_VENDORS } from '../utils/constants';
+import { useSnackbar } from './hooks/useSnackbar';
+import SnackbarFeedback from './SnackbarFeedback';
 
 // Card vendor definitions with their logos and colors
 export const CARD_VENDORS = {
@@ -203,11 +203,7 @@ export default function CardVendorsModal({ isOpen, onClose }: CardVendorsModalPr
   const [originalValues, setOriginalValues] = useState<typeof editValues | null>(null);
   const [, setIsSaving] = useState(false);
   const [_lastSaved, setLastSaved] = useState<Date | null>(null);
-  const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: 'success' | 'error' }>({
-    open: false,
-    message: '',
-    severity: 'success',
-  });
+  const { snackbar, showSnackbar, hideSnackbar } = useSnackbar();
 
   const fetchCards = useCallback(async () => {
     try {
@@ -219,15 +215,14 @@ export default function CardVendorsModal({ isOpen, onClose }: CardVendorsModalPr
       const data = await response.json();
       setCards(data);
     } catch (err) {
-      setSnackbar({
-        open: true,
-        message: err instanceof Error ? err.message : t('misc:cardVendors.errors.generic'),
-        severity: 'error',
-      });
+      showSnackbar(
+        err instanceof Error ? err.message : t('misc:cardVendors.errors.generic'),
+        'error'
+      );
     } finally {
       setIsLoading(false);
     }
-  }, [t]);
+  }, [showSnackbar, t]);
 
   const fetchBankAccounts = useCallback(async () => {
     try {
@@ -371,16 +366,15 @@ export default function CardVendorsModal({ isOpen, onClose }: CardVendorsModalPr
 
       return true;
     } catch (err) {
-      setSnackbar({
-        open: true,
-        message: err instanceof Error ? err.message : t('misc:cardVendors.errors.saveFailed'),
-        severity: 'error',
-      });
+      showSnackbar(
+        err instanceof Error ? err.message : t('misc:cardVendors.errors.saveFailed'),
+        'error'
+      );
       return false;
     } finally {
       setIsSaving(false);
     }
-  }, [bankAccounts, cards, t]);
+  }, [bankAccounts, cards, showSnackbar, t]);
 
   useEffect(() => {
     if (!editingCard || !originalValues) return;
@@ -447,7 +441,7 @@ export default function CardVendorsModal({ isOpen, onClose }: CardVendorsModalPr
                 handleSave(editingCard, newValues).then((success) => {
                   if (success) {
                     setEditingCard(null);
-                    setSnackbar({ open: true, message: t('misc:cardVendors.snackbar.vendorUpdated'), severity: 'success' });
+                    showSnackbar(t('misc:cardVendors.snackbar.vendorUpdated'), 'success');
                   }
                 });
               }, 200);
@@ -524,7 +518,7 @@ export default function CardVendorsModal({ isOpen, onClose }: CardVendorsModalPr
               handleSave(editingCard, editValues).then((success) => {
                 if (success) {
                   setEditingCard(null);
-                  setSnackbar({ open: true, message: t('misc:cardVendors.snackbar.nicknameSaved'), severity: 'success' });
+                  showSnackbar(t('misc:cardVendors.snackbar.nicknameSaved'), 'success');
                 }
               });
             } else {
@@ -587,7 +581,7 @@ export default function CardVendorsModal({ isOpen, onClose }: CardVendorsModalPr
                     handleSave(editingCard, newValues).then((success) => {
                       if (success) {
                         setEditingCard(null);
-                        setSnackbar({ open: true, message: t('misc:cardVendors.snackbar.bankAccountUpdated'), severity: 'success' });
+                        showSnackbar(t('misc:cardVendors.snackbar.bankAccountUpdated'), 'success');
                       }
                     });
                   }, 200);
@@ -632,7 +626,7 @@ export default function CardVendorsModal({ isOpen, onClose }: CardVendorsModalPr
                     handleSave(editingCard, editValues).then((success) => {
                       if (success) {
                         setEditingCard(null);
-                        setSnackbar({ open: true, message: t('misc:cardVendors.snackbar.customBankSaved'), severity: 'success' });
+                        showSnackbar(t('misc:cardVendors.snackbar.customBankSaved'), 'success');
                       }
                     });
                   }
@@ -688,7 +682,7 @@ export default function CardVendorsModal({ isOpen, onClose }: CardVendorsModalPr
         </Typography>
       )
     }
-  ], [editingCard, editValues, originalValues, bankAccounts, theme, focusedField, t, handleEdit, handleSave]);
+  ], [editingCard, editValues, originalValues, bankAccounts, theme, focusedField, t, handleEdit, handleSave, showSnackbar]);
 
   return (
     <>
@@ -833,24 +827,17 @@ export default function CardVendorsModal({ isOpen, onClose }: CardVendorsModalPr
           }
         </DialogContent >
       </Dialog >
-      <Snackbar
-        open={snackbar.open}
+      <SnackbarFeedback
+        snackbar={snackbar}
+        onClose={hideSnackbar}
         autoHideDuration={4000}
-        onClose={() => setSnackbar({ ...snackbar, open: false })}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-      >
-        <Alert
-          onClose={() => setSnackbar({ ...snackbar, open: false })}
-          severity={snackbar.severity}
-          sx={{
-            width: '100%',
-            borderRadius: '12px',
-            boxShadow: '0 4px 20px rgba(0, 0, 0, 0.15)',
-          }}
-        >
-          {snackbar.message}
-        </Alert>
-      </Snackbar>
+        alertSx={{
+          width: '100%',
+          borderRadius: '12px',
+          boxShadow: '0 4px 20px rgba(0, 0, 0, 0.15)',
+        }}
+      />
     </>
   );
 }

--- a/app/components/CardVendorsModal.tsx
+++ b/app/components/CardVendorsModal.tsx
@@ -93,7 +93,7 @@ interface BankAccount {
 }
 
 interface CardVendorsModalProps {
-  isOpen: boolean;
+  open: boolean;
   onClose: () => void;
 }
 
@@ -179,7 +179,7 @@ export const CardVendorIcon: React.FC<{ vendor: string | null; size?: number }> 
   );
 };
 
-export default function CardVendorsModal({ isOpen, onClose }: CardVendorsModalProps) {
+export default function CardVendorsModal({ open, onClose }: CardVendorsModalProps) {
   const theme = useTheme();
   const { t } = useTranslation(['misc', 'common']);
   const [cards, setCards] = useState<CardData[]>([]);
@@ -240,12 +240,12 @@ export default function CardVendorsModal({ isOpen, onClose }: CardVendorsModalPr
   }, []);
 
   useEffect(() => {
-    if (!isOpen) return;
+    if (!open) return;
     queueMicrotask(() => {
       fetchCards();
       fetchBankAccounts();
     });
-  }, [isOpen, fetchCards, fetchBankAccounts]);
+  }, [open, fetchCards, fetchBankAccounts]);
 
   const handleEdit = useCallback((card: CardData, field: string = 'vendor', event?: React.MouseEvent) => {
     if (event) {
@@ -687,7 +687,7 @@ export default function CardVendorsModal({ isOpen, onClose }: CardVendorsModalPr
   return (
     <>
       <Dialog
-        open={isOpen}
+        open={open}
         onClose={onClose}
         maxWidth="xl"
         fullWidth

--- a/app/components/CardVendorsModal.tsx
+++ b/app/components/CardVendorsModal.tsx
@@ -406,7 +406,7 @@ export default function CardVendorsModal({ open, onClose }: CardVendorsModalProp
         <Typography
           sx={{
             backgroundColor: 'rgba(99, 102, 241, 0.1)',
-            color: '#6366f1',
+            color: 'var(--n-primary-500)',
             padding: '4px 12px',
             borderRadius: '20px',
             fontSize: '14px',
@@ -754,7 +754,7 @@ export default function CardVendorsModal({ open, onClose }: CardVendorsModalProp
                       <Typography
                         sx={{
                           backgroundColor: 'rgba(99, 102, 241, 0.1)',
-                          color: '#6366f1',
+                          color: 'var(--n-primary-500)',
                           padding: '2px 8px',
                           borderRadius: '12px',
                           fontSize: '12px',

--- a/app/components/CategoryAutocomplete.tsx
+++ b/app/components/CategoryAutocomplete.tsx
@@ -56,10 +56,10 @@ const CategoryAutocomplete: React.FC<CategoryAutocompleteProps> = ({
                             borderColor: '#e2e8f0',
                         },
                         '&:hover fieldset': {
-                            borderColor: '#3b82f6',
+                            borderColor: 'var(--n-info)',
                         },
                         '&.Mui-focused fieldset': {
-                            borderColor: '#3b82f6',
+                            borderColor: 'var(--n-info)',
                         },
                     },
                 }}
@@ -88,7 +88,7 @@ const CategoryAutocomplete: React.FC<CategoryAutocompleteProps> = ({
                                 sx={{
                                     color: '#94a3b8',
                                     '&.Mui-checked': {
-                                        color: '#3b82f6',
+                                        color: 'var(--n-info)',
                                     },
                                     padding: '2px',
                                 }}

--- a/app/components/CategoryDashboard/components/Card.tsx
+++ b/app/components/CategoryDashboard/components/Card.tsx
@@ -35,7 +35,7 @@ interface CardProps {
 // Mini burndown chart component
 const BurndownChart: React.FC<{ percentUsed: number; isOverBudget: boolean }> = ({ percentUsed, isOverBudget }) => {
   const clampedPercent = Math.min(percentUsed, 100);
-  const chartColor = isOverBudget ? '#ef4444' : percentUsed >= 80 ? '#f59e0b' : '#22c55e';
+  const chartColor = isOverBudget ? 'var(--n-error)' : percentUsed >= 80 ? 'var(--n-warning)' : '#22c55e';
 
   return (
     <div style={{
@@ -233,7 +233,7 @@ const Card: React.FC<CardProps> = ({
             <span style={{
               fontSize: valueSize,
               fontWeight: size === 'large' ? '800' : '700',
-              color: budget ? (budget.is_over_budget ? '#ef4444' : color) : color,
+              color: budget ? (budget.is_over_budget ? 'var(--n-error)' : color) : color,
               letterSpacing: '-0.02em',
               fontFamily: 'Assistant, sans-serif',
               textShadow: `0 2px 12px ${color}60`

--- a/app/components/CategoryDashboard/components/CategoryManagementModal.tsx
+++ b/app/components/CategoryDashboard/components/CategoryManagementModal.tsx
@@ -859,7 +859,7 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
                 }}
               >
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                  <FlashOnIcon sx={{ fontSize: 18, color: uncategorizedDescriptions.length > 0 ? '#f59e0b' : 'inherit' }} />
+                  <FlashOnIcon sx={{ fontSize: 18, color: uncategorizedDescriptions.length > 0 ? 'var(--n-warning)' : 'inherit' }} />
                   {t('categoryMgmt:tabs.uncategorized')}
                 </Box>
               </Badge>
@@ -884,7 +884,7 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
                       : 'linear-gradient(135deg, rgba(59, 130, 246, 0.05) 0%, rgba(147, 51, 234, 0.05) 100%)',
                     borderRadius: '12px',
                     padding: '16px',
-                    border: `2px dashed ${selectedCategories.length >= 2 ? '#3b82f6' : theme.palette.divider}`,
+                    border: `2px dashed ${selectedCategories.length >= 2 ? 'var(--n-info)' : theme.palette.divider}`,
                     minHeight: '120px',
                     display: 'flex',
                     flexDirection: 'column',
@@ -892,7 +892,7 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
                   }}
                 >
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-                    <MergeIcon sx={{ color: '#3b82f6', fontSize: 20 }} />
+                    <MergeIcon sx={{ color: 'var(--n-info)', fontSize: 20 }} />
                     <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
                       {t('categoryMgmt:categories.selectedToMerge', { count: selectedCategories.length })}
                     </Typography>
@@ -918,7 +918,7 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
                           size="small"
                           onDelete={() => handleCategoryToggle(catName)}
                           sx={{
-                            background: categoryColors[catName] || '#3b82f6',
+                            background: categoryColors[catName] || 'var(--n-info)',
                             color: '#fff',
                             fontWeight: 500,
                             '& .MuiChip-deleteIcon': { color: 'rgba(255,255,255,0.7)' }
@@ -1074,15 +1074,15 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
                           borderRadius: '8px',
                           cursor: 'pointer',
                           border: selectedCategories.includes(category.name)
-                            ? `2px solid ${categoryColors[category.name] || '#3b82f6'}`
+                            ? `2px solid ${categoryColors[category.name] || 'var(--n-info)'}`
                             : `1px solid ${theme.palette.divider}`,
                           background: selectedCategories.includes(category.name)
-                            ? `linear-gradient(135deg, ${categoryColors[category.name] || '#3b82f6'}15 0%, ${categoryColors[category.name] || '#3b82f6'}05 100%)`
+                            ? `linear-gradient(135deg, ${categoryColors[category.name] || 'var(--n-info)'}15 0%, ${categoryColors[category.name] || 'var(--n-info)'}05 100%)`
                             : theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.03)' : '#fff',
                           transition: 'all 0.15s ease',
                           '&:hover': {
                             boxShadow: '0 2px 6px rgba(0, 0, 0, 0.08)',
-                            borderColor: categoryColors[category.name] || '#3b82f6'
+                            borderColor: categoryColors[category.name] || 'var(--n-info)'
                           }
                         }}
                       >
@@ -1097,7 +1097,7 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
                                   ? 'none'
                                   : `1.5px solid ${theme.palette.divider}`,
                                 background: selectedCategories.includes(category.name)
-                                  ? categoryColors[category.name] || '#3b82f6'
+                                  ? categoryColors[category.name] || 'var(--n-info)'
                                   : 'transparent',
                                 display: 'flex',
                                 alignItems: 'center',
@@ -1167,7 +1167,7 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
                     onClick={handleCreateRule}
                     disabled={!newRule.name_pattern.trim() || !newRule.target_category.trim() || isLoading}
                     style={{
-                      backgroundColor: '#10b981',
+                      backgroundColor: 'var(--n-success)',
                       color: 'white',
                       borderRadius: '12px',
                       padding: '10px 16px',
@@ -1188,8 +1188,8 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
                 onClick={handleApplyRules}
                 disabled={isApplyingRules || rules.length === 0}
                 style={{
-                  borderColor: '#3b82f6',
-                  color: '#3b82f6',
+                  borderColor: 'var(--n-info)',
+                  color: 'var(--n-info)',
                   borderRadius: '12px',
                   padding: '10px 24px',
                   textTransform: 'none',
@@ -1267,7 +1267,7 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
                                 size="medium"
                                 sx={{
                                   padding: { xs: '8px', sm: '4px' },
-                                  color: '#3b82f6',
+                                  color: 'var(--n-info)',
                                   '& .MuiSvgIcon-root': {
                                     fontSize: { xs: '20px', sm: '16px' }
                                   }
@@ -1280,7 +1280,7 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
                                 size="medium"
                                 sx={{
                                   padding: { xs: '8px', sm: '4px' },
-                                  color: '#ef4444',
+                                  color: 'var(--n-error)',
                                   '& .MuiSvgIcon-root': {
                                     fontSize: { xs: '20px', sm: '16px' }
                                   }
@@ -1356,7 +1356,7 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
                   onClick={() => editingRule && handleUpdateRule(editingRule)}
                   disabled={isLoading}
                   sx={{
-                    bgcolor: '#3b82f6',
+                    bgcolor: 'var(--n-info)',
                     '&:hover': { bgcolor: '#2563eb' },
                     borderRadius: '8px',
                     textTransform: 'none',
@@ -1383,7 +1383,7 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
                   marginBottom: 2,
                   backgroundColor: 'rgba(59, 130, 246, 0.1)',
                   '& .MuiLinearProgress-bar': {
-                    backgroundColor: '#3b82f6'
+                    backgroundColor: 'var(--n-info)'
                   }
                 }}
               />
@@ -1453,7 +1453,7 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
                     size="small"
                     sx={{
                       backgroundColor: 'rgba(59, 130, 246, 0.1)',
-                      color: '#3b82f6',
+                      color: 'var(--n-info)',
                       fontWeight: 600
                     }}
                   />
@@ -1507,7 +1507,7 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
                         size="small"
                         sx={{
                           backgroundColor: 'rgba(59, 130, 246, 0.1)',
-                          color: '#3b82f6',
+                          color: 'var(--n-info)',
                           fontWeight: 600
                         }}
                       />
@@ -1516,7 +1516,7 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
                         size="small"
                         sx={{
                           backgroundColor: 'rgba(239, 68, 68, 0.1)',
-                          color: '#ef4444',
+                          color: 'var(--n-error)',
                           fontWeight: 600
                         }}
                       />
@@ -1553,7 +1553,7 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
                               <TableCell sx={{ color: theme.palette.text.secondary, fontSize: '0.8125rem' }}>
                                 {formatQuickDate(tx.date)}
                               </TableCell>
-                              <TableCell sx={{ color: tx.price < 0 ? '#ef4444' : '#22c55e', fontWeight: 600, fontSize: '0.8125rem' }}>
+                              <TableCell sx={{ color: tx.price < 0 ? 'var(--n-error)' : '#22c55e', fontWeight: 600, fontSize: '0.8125rem' }}>
                                 {formatQuickCurrency(Math.abs(tx.price))}
                               </TableCell>
                               <TableCell sx={{ color: theme.palette.text.secondary, fontSize: '0.8125rem' }}>
@@ -1607,7 +1607,7 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
                       onClick={() => handleQuickCategorySelect(cat.name)}
                       disabled={isSavingQuick}
                       sx={{
-                        backgroundColor: categoryColors[cat.name] || '#3b82f6',
+                        backgroundColor: categoryColors[cat.name] || 'var(--n-info)',
                         color: '#fff',
                         textTransform: 'none',
                         fontWeight: 600,
@@ -1616,7 +1616,7 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
                         fontSize: '13px',
                         minWidth: 'auto',
                         '&:hover': {
-                          backgroundColor: categoryColors[cat.name] || '#3b82f6',
+                          backgroundColor: categoryColors[cat.name] || 'var(--n-info)',
                           filter: 'brightness(1.1)',
                           transform: 'translateY(-1px)',
                         },
@@ -1713,7 +1713,7 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
                 {t('categoryMgmt:mappings.description')}
               </Typography>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, backgroundColor: theme.palette.mode === 'dark' ? 'rgba(59, 130, 246, 0.1)' : 'rgba(59, 130, 246, 0.05)', padding: '12px', borderRadius: '12px', marginBottom: '20px' }}>
-                <HelpOutlineIcon sx={{ color: '#3b82f6', fontSize: 20 }} />
+                <HelpOutlineIcon sx={{ color: 'var(--n-info)', fontSize: 20 }} />
                 <Typography variant="body2" sx={{ color: theme.palette.mode === 'dark' ? '#93c5fd' : '#1e40af' }}>
                   {t('categoryMgmt:mappings.infoNotice')}
                 </Typography>
@@ -1880,7 +1880,7 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
                                     label={mapping.target_category}
                                     size="small"
                                     sx={{
-                                      backgroundColor: categoryColors[mapping.target_category] || '#3b82f6',
+                                      backgroundColor: categoryColors[mapping.target_category] || 'var(--n-info)',
                                       color: '#fff',
                                       fontWeight: 600
                                     }}
@@ -1914,7 +1914,7 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
                                       setEditMappingTarget(mapping.target_category);
                                     }}
                                     size="small"
-                                    sx={{ color: '#3b82f6', mr: 1 }}
+                                    sx={{ color: 'var(--n-info)', mr: 1 }}
                                     title={t('categoryMgmt:mappings.tooltipEditTarget')}
                                   >
                                     <EditIcon />
@@ -1922,7 +1922,7 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
                                   <IconButton
                                     onClick={() => handleDeleteMapping(mapping.id)}
                                     size="small"
-                                    style={{ color: '#ef4444' }}
+                                    style={{ color: 'var(--n-error)' }}
                                     title={t('categoryMgmt:mappings.tooltipRemove')}
                                   >
                                     <DeleteIcon />
@@ -1957,7 +1957,7 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
             }
           }}
         >
-          <DialogTitle sx={{ fontWeight: 700, color: '#ef4444' }}>{t('categoryMgmt:deleteDialog.title')}</DialogTitle>
+          <DialogTitle sx={{ fontWeight: 700, color: 'var(--n-error)' }}>{t('categoryMgmt:deleteDialog.title')}</DialogTitle>
           <DialogContent>
             <Typography
               variant="body2"
@@ -2006,7 +2006,7 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
               onClick={handleDeleteCategory}
               disabled={isLoading}
               sx={{
-                bgcolor: '#ef4444',
+                bgcolor: 'var(--n-error)',
                 '&:hover': { bgcolor: '#dc2626' },
                 borderRadius: '8px',
                 textTransform: 'none',
@@ -2078,7 +2078,7 @@ const CategoryManagementModal: React.FC<CategoryManagementModalProps> = ({
               onClick={handleRenameCategory}
               disabled={isLoading || !renameNewName.trim() || renameNewName.trim() === renamingCategory}
               sx={{
-                bgcolor: '#3b82f6',
+                bgcolor: 'var(--n-info)',
                 '&:hover': { bgcolor: '#2563eb' },
                 borderRadius: '8px',
                 textTransform: 'none',

--- a/app/components/CategoryDashboard/components/ExpensesModal.tsx
+++ b/app/components/CategoryDashboard/components/ExpensesModal.tsx
@@ -5,13 +5,13 @@ import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import ModalHeader from '../../ModalHeader';
 
-import Snackbar from '@mui/material/Snackbar';
-import Alert from '@mui/material/Alert';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 import { ExpensesModalProps, Expense } from '../types';
 import Box from '@mui/material/Box';
 import TransactionsTable from './TransactionsTable';
+import { useSnackbar } from '../../hooks/useSnackbar';
+import SnackbarFeedback from '../../SnackbarFeedback';
 
 type SortField = 'date' | 'processed_date' | 'price' | 'installments_number' | 'name' | 'category' | 'card';
 type SortDirection = 'asc' | 'desc';
@@ -22,11 +22,7 @@ const ExpensesModal: React.FC<ExpensesModalProps> = ({ open, onClose, data, setM
   const theme = useTheme();
   const { t } = useTranslation('tx');
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
-  const [snackbar, setSnackbar] = React.useState<{ open: boolean; message: string; severity: 'success' | 'error' | 'info' }>({
-    open: false,
-    message: '',
-    severity: 'success'
-  });
+  const { snackbar, showSnackbar, hideSnackbar } = useSnackbar<'success' | 'error' | 'info'>();
   const [sortField, setSortField] = React.useState<SortField>('date');
   const [sortDirection, setSortDirection] = React.useState<SortDirection>('desc');
 
@@ -108,19 +104,11 @@ const ExpensesModal: React.FC<ExpensesModalProps> = ({ open, onClose, data, setM
         // Trigger a refresh of the dashboard data
         window.dispatchEvent(new CustomEvent('dataRefresh'));
       } else {
-        setSnackbar({
-          open: true,
-          message: t('snackbar.updateTransactionFailed'),
-          severity: 'error'
-        });
+        showSnackbar(t('snackbar.updateTransactionFailed'), 'error');
       }
     } catch (error) {
       logger.error('Error updating transaction', error as Error);
-      setSnackbar({
-        open: true,
-        message: t('snackbar.updateTransactionError'),
-        severity: 'error'
-      });
+      showSnackbar(t('snackbar.updateTransactionError'), 'error');
     }
   };
 
@@ -148,36 +136,19 @@ const ExpensesModal: React.FC<ExpensesModalProps> = ({ open, onClose, data, setM
             data: updatedData
           });
 
-          setSnackbar({
-            open: true,
-            message: t('snackbar.deleteSuccess'),
-            severity: 'success'
-          });
+          showSnackbar(t('snackbar.deleteSuccess'), 'success');
 
-          // Trigger a refresh of the dashboard data
           window.dispatchEvent(new CustomEvent('dataRefresh'));
         } else {
-          setSnackbar({
-            open: true,
-            message: t('snackbar.deleteTransactionFailed'),
-            severity: 'error'
-          });
+          showSnackbar(t('snackbar.deleteTransactionFailed'), 'error');
         }
       } else {
         logger.error('Cannot delete transaction: missing identifier or vendor', expense);
-        setSnackbar({
-          open: true,
-          message: t('snackbar.missingIdentifier'),
-          severity: 'error'
-        });
+        showSnackbar(t('snackbar.missingIdentifier'), 'error');
       }
     } catch (error) {
       logger.error('Error deleting transaction', error as Error);
-      setSnackbar({
-        open: true,
-        message: t('snackbar.deleteError'),
-        severity: 'error'
-      });
+      showSnackbar(t('snackbar.deleteError'), 'error');
     }
   };
 
@@ -235,25 +206,17 @@ const ExpensesModal: React.FC<ExpensesModalProps> = ({ open, onClose, data, setM
           />
         </Box>
       </DialogContent >
-      {/* Snackbar for feedback messages */}
-      < Snackbar
-        open={snackbar.open}
+      <SnackbarFeedback
+        snackbar={snackbar}
+        onClose={hideSnackbar}
         autoHideDuration={5000}
-        onClose={() => setSnackbar({ ...snackbar, open: false })}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-      >
-        <Alert
-          onClose={() => setSnackbar({ ...snackbar, open: false })}
-          severity={snackbar.severity}
-          sx={{
-            width: '100%',
-            borderRadius: '12px',
-            boxShadow: '0 4px 20px rgba(0, 0, 0, 0.15)'
-          }}
-        >
-          {snackbar.message}
-        </Alert>
-      </Snackbar >
+        alertSx={{
+          width: '100%',
+          borderRadius: '12px',
+          boxShadow: '0 4px 20px rgba(0, 0, 0, 0.15)'
+        }}
+      />
     </Dialog >
   );
 };

--- a/app/components/CategoryDashboard/components/TransactionsTable.tsx
+++ b/app/components/CategoryDashboard/components/TransactionsTable.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { logger } from '../../../utils/client-logger';
 import { useTheme, type Theme } from '@mui/material/styles';
-import { Table, TableBody, TableCell, TableHead, TableRow, Paper, Box, Typography, IconButton, TextField, Snackbar, Alert, Tooltip, TableSortLabel, useMediaQuery, Button } from '@mui/material';
+import { Table, TableBody, TableCell, TableHead, TableRow, Paper, Box, Typography, IconButton, TextField, Tooltip, TableSortLabel, useMediaQuery, Button } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
 import CheckIcon from '@mui/icons-material/Check';
@@ -21,6 +21,8 @@ import AccountDisplay from '../../AccountDisplay';
 import MobileSortableTable, { SortOption } from '../../MobileSortableTable';
 import { useTranslation } from 'react-i18next';
 import { useLocale } from '../../../context/LocaleContext';
+import { useSnackbar } from '../../hooks/useSnackbar';
+import SnackbarFeedback from '../../SnackbarFeedback';
 
 const getCurrencySymbol = (currency?: string) => {
   if (!currency) return '₪';
@@ -92,11 +94,7 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
   const [applyToAll, setApplyToAll] = React.useState<boolean>(false);
   const { categories: availableCategories } = useCategories();
   const { getCardVendor, getCardNickname } = useCardVendors();
-  const [snackbar, setSnackbar] = React.useState<{ open: boolean; message: string; severity: 'success' | 'error' | 'info' }>({
-    open: false,
-    message: '',
-    severity: 'success'
-  });
+  const { snackbar, showSnackbar, hideSnackbar } = useSnackbar<'success' | 'error' | 'info'>();
   const [confirmDeleteTransaction, setConfirmDeleteTransaction] = React.useState<Transaction | null>(null);
   const [editingNotes, setEditingNotes] = React.useState<{ identifier: string; vendor: string; content: string } | null>(null);
 
@@ -122,13 +120,13 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
     if (!confirmDeleteTransaction) return;
     try {
       onDelete?.(confirmDeleteTransaction);
-      setSnackbar({ open: true, message: t('tx:snackbar.deleteSuccess'), severity: 'success' });
+      showSnackbar(t('tx:snackbar.deleteSuccess'), 'success');
     } catch (error) {
       logger.error('Error deleting transaction', error as Error);
-      setSnackbar({ open: true, message: t('tx:snackbar.deleteError'), severity: 'error' });
+      showSnackbar(t('tx:snackbar.deleteError'), 'error');
     }
     setConfirmDeleteTransaction(null);
-  }, [confirmDeleteTransaction, onDelete, t]);
+  }, [confirmDeleteTransaction, onDelete, showSnackbar, t]);
 
   const handleEditClick = React.useCallback((transaction: Transaction) => {
     setEditingTransaction(transaction);
@@ -161,13 +159,12 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 
               if (response.ok) {
                 const result = await response.json();
-                setSnackbar({
-                  open: true,
-                  message: result.transactionsUpdated > 1
+                showSnackbar(
+                  result.transactionsUpdated > 1
                     ? t('tx:snackbar.updatedManyAndRule', { count: result.transactionsUpdated })
                     : t('tx:snackbar.categoryUpdatedAndRule'),
-                  severity: 'success'
-                });
+                  'success'
+                );
                 onUpdate?.(editingTransaction, { category: editCategory, price: priceWithSign });
                 window.dispatchEvent(new CustomEvent('dataRefresh'));
               }
@@ -179,12 +176,12 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
           }
         } catch (error) {
           logger.error('Error updating transaction', error as Error);
-          setSnackbar({ open: true, message: t('tx:snackbar.updateError'), severity: 'error' });
+          showSnackbar(t('tx:snackbar.updateError'), 'error');
         }
         setEditingTransaction(null);
       }
     }
-  }, [editingTransaction, editPrice, editCategory, applyToAll, onUpdate, isBankView, t]);
+  }, [editingTransaction, editPrice, editCategory, applyToAll, onUpdate, isBankView, showSnackbar, t]);
 
   const handleCancelClick = React.useCallback(() => {
     setEditingTransaction(null);
@@ -382,9 +379,7 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
           </TableBody>
         </Table>
       )}
-      <Snackbar open={snackbar.open} autoHideDuration={6000} onClose={() => setSnackbar({ ...snackbar, open: false })}>
-        <Alert severity={snackbar.severity} onClose={() => setSnackbar({ ...snackbar, open: false })}>{snackbar.message}</Alert>
-      </Snackbar>
+      <SnackbarFeedback snackbar={snackbar} onClose={hideSnackbar} />
       <DeleteConfirmationDialog
         open={!!confirmDeleteTransaction}
         onClose={() => setConfirmDeleteTransaction(null)}

--- a/app/components/CategoryDashboard/components/TransactionsTable.tsx
+++ b/app/components/CategoryDashboard/components/TransactionsTable.tsx
@@ -505,11 +505,11 @@ const TransactionRow = React.memo(({
       <TableCell style={cellStyle}>
         {editingTransaction?.identifier === transaction.identifier && !hideActions ? (
           <CategoryAutocomplete value={editCategory} onChange={setEditCategory} options={availableCategories} applyToAll={applyToAll} onApplyToAllChange={setApplyToAll} showApplyToAll={editCategory !== editingTransaction.category} />
-        ) : <span style={{ cursor: 'pointer', color: '#3b82f6' }} onClick={(e) => { e.stopPropagation(); handleEditClick(transaction); }}>{transaction.category}</span>}
+        ) : <span style={{ cursor: 'pointer', color: 'var(--n-info)' }} onClick={(e) => { e.stopPropagation(); handleEditClick(transaction); }}>{transaction.category}</span>}
       </TableCell>
       <TableCell align="right" style={{
         ...cellStyle,
-        color: transaction.price < 0 ? '#ef4444' : '#10b981',
+        color: transaction.price < 0 ? 'var(--n-error)' : 'var(--n-success)',
         fontWeight: 600
       }}>
         {editingTransaction?.identifier === transaction.identifier && !hideActions ? (
@@ -546,19 +546,19 @@ const TransactionRow = React.memo(({
                 <IconButton onClick={handleSaveClick} sx={{ color: '#4ADE80' }}><CheckIcon /></IconButton>
               </Tooltip>
               <Tooltip title={t('common:actions.cancel')}>
-                <IconButton onClick={handleCancelClick} sx={{ color: '#ef4444' }}><CloseIcon /></IconButton>
+                <IconButton onClick={handleCancelClick} sx={{ color: 'var(--n-error)' }}><CloseIcon /></IconButton>
               </Tooltip>
             </>
           ) : (
             <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
               <Tooltip title={t('tx:tooltips.editTransaction')}>
-                <IconButton onClick={(e) => { e.stopPropagation(); handleEditClick(transaction); }} size="small" sx={{ color: '#3b82f6' }}><EditIcon fontSize="small" /></IconButton>
+                <IconButton onClick={(e) => { e.stopPropagation(); handleEditClick(transaction); }} size="small" sx={{ color: 'var(--n-info)' }}><EditIcon fontSize="small" /></IconButton>
               </Tooltip>
               <Tooltip title={transaction.notes ? t('tx:tooltips.viewNotes') : t('tx:tooltips.openNotes')}>
                 <IconButton onClick={(e) => { e.stopPropagation(); setEditingNotes({ identifier: transaction.identifier, vendor: transaction.vendor, content: transaction.notes || '' }); }} size="small" sx={{ color: transaction.notes ? theme.palette.primary.main : theme.palette.text.disabled }}><NotesIcon fontSize="small" /></IconButton>
               </Tooltip>
               <Tooltip title={t('tx:tooltips.deleteTransaction')}>
-                <IconButton onClick={(e) => { e.stopPropagation(); setConfirmDeleteTransaction(transaction); }} size="small" sx={{ color: '#ef4444' }}><DeleteIcon fontSize="small" /></IconButton>
+                <IconButton onClick={(e) => { e.stopPropagation(); setConfirmDeleteTransaction(transaction); }} size="small" sx={{ color: 'var(--n-error)' }}><DeleteIcon fontSize="small" /></IconButton>
               </Tooltip>
             </Box>
           )}
@@ -664,14 +664,14 @@ const TransactionMobileCardContent = ({
               }}>{transaction.notes}</Typography>}
           </Box>
         </Box>
-        <Typography variant="subtitle2" sx={{ fontWeight: 800, color: transaction.price < 0 ? '#ef4444' : '#10b981' }}>
+        <Typography variant="subtitle2" sx={{ fontWeight: 800, color: transaction.price < 0 ? 'var(--n-error)' : 'var(--n-success)' }}>
           {isBankView && transaction.price >= 0 ? '+' : ''}₪{formatNumber(Math.abs(transaction.price))}
         </Typography>
       </Box>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
         {isEditing ? (
           <CategoryAutocomplete value={editCategory || ''} onChange={setEditCategory || (() => { })} options={availableCategories || []} applyToAll={applyToAll || false} onApplyToAllChange={setApplyToAll || (() => { })} showApplyToAll={editCategory !== transaction.category} />
-        ) : <Typography variant="caption" sx={{ color: '#3b82f6', background: 'rgba(59, 130, 246, 0.1)', p: '2px 8px', borderRadius: 1 }}>{transaction.category}</Typography>}
+        ) : <Typography variant="caption" sx={{ color: 'var(--n-info)', background: 'rgba(59, 130, 246, 0.1)', p: '2px 8px', borderRadius: 1 }}>{transaction.category}</Typography>}
       </Box>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <Box sx={{ display: 'flex', alignItems: 'center' }}>
@@ -682,22 +682,22 @@ const TransactionMobileCardContent = ({
           {isEditing ? (
             <>
               <Tooltip title={t('common:actions.save')}>
-                <IconButton size="small" onClick={onSave} sx={{ color: '#10b981' }}><CheckIcon fontSize="small" /></IconButton>
+                <IconButton size="small" onClick={onSave} sx={{ color: 'var(--n-success)' }}><CheckIcon fontSize="small" /></IconButton>
               </Tooltip>
               <Tooltip title={t('common:actions.cancel')}>
-                <IconButton size="small" onClick={onCancel} sx={{ color: '#ef4444' }}><CloseIcon fontSize="small" /></IconButton>
+                <IconButton size="small" onClick={onCancel} sx={{ color: 'var(--n-error)' }}><CloseIcon fontSize="small" /></IconButton>
               </Tooltip>
             </>
           ) : (
             <>
               <Tooltip title={t('tx:tooltips.editTransaction')}>
-                <IconButton size="small" onClick={onEdit} sx={{ color: '#3b82f6' }}><EditIcon fontSize="small" /></IconButton>
+                <IconButton size="small" onClick={onEdit} sx={{ color: 'var(--n-info)' }}><EditIcon fontSize="small" /></IconButton>
               </Tooltip>
               <Tooltip title={transaction.notes ? t('tx:tooltips.viewNotes') : t('tx:tooltips.openNotes')}>
                 <IconButton size="small" onClick={() => setShowNoteInput(!showNoteInput)} sx={{ color: transaction.notes ? theme.palette.primary.main : theme.palette.text.disabled }}><NotesIcon fontSize="small" /></IconButton>
               </Tooltip>
               <Tooltip title={t('tx:tooltips.deleteTransaction')}>
-                <IconButton size="small" onClick={onDelete} sx={{ color: '#ef4444' }}><DeleteIcon fontSize="small" /></IconButton>
+                <IconButton size="small" onClick={onDelete} sx={{ color: 'var(--n-error)' }}><DeleteIcon fontSize="small" /></IconButton>
               </Tooltip>
             </>
           )}

--- a/app/components/ChatView.tsx
+++ b/app/components/ChatView.tsx
@@ -324,9 +324,9 @@ const ChatView: React.FC = () => {
                             fontWeight: 600,
                             py: 1,
                             borderColor: 'rgba(99, 102, 241, 0.3)',
-                            color: '#6366f1',
+                            color: 'var(--n-primary-500)',
                             '&:hover': {
-                                borderColor: '#6366f1',
+                                borderColor: 'var(--n-primary-500)',
                                 backgroundColor: 'rgba(99, 102, 241, 0.04)',
                             }
                         }}
@@ -363,7 +363,7 @@ const ChatView: React.FC = () => {
                                             }
                                         }}
                                     >
-                                        <ListItemIcon sx={{ minWidth: 36, color: currentSessionId === session.id ? '#6366f1' : 'text.secondary' }}>
+                                        <ListItemIcon sx={{ minWidth: 36, color: currentSessionId === session.id ? 'var(--n-primary-500)' : 'text.secondary' }}>
                                             <ChatIcon fontSize="small" />
                                         </ListItemIcon>
                                         <ListItemText
@@ -381,7 +381,7 @@ const ChatView: React.FC = () => {
                                         <IconButton
                                             size="small"
                                             onClick={(e) => deleteSession(e, session.id)}
-                                            sx={{ opacity: 0, '.MuiListItemButton-root:hover &': { opacity: 0.6 }, '&:hover': { opacity: 1, color: '#ef4444' } }}
+                                            sx={{ opacity: 0, '.MuiListItemButton-root:hover &': { opacity: 0.6 }, '&:hover': { opacity: 1, color: 'var(--n-error)' } }}
                                         >
                                             <DeleteOutlineIcon fontSize="small" />
                                         </IconButton>
@@ -429,7 +429,7 @@ const ChatView: React.FC = () => {
                                             textTransform: 'none',
                                             borderColor: 'divider',
                                             color: 'text.secondary',
-                                            '&:hover': { borderColor: '#6366f1', color: '#6366f1' }
+                                            '&:hover': { borderColor: 'var(--n-primary-500)', color: 'var(--n-primary-500)' }
                                         }}
                                     >
                                         {q}
@@ -478,13 +478,13 @@ const ChatView: React.FC = () => {
                                                 sx={{
                                                     fontSize: '0.95rem',
                                                     lineHeight: 1.6,
-                                                    color: msg.status === 'error' ? '#ef4444' : 'inherit',
+                                                    color: msg.status === 'error' ? 'var(--n-error)' : 'inherit',
                                                     fontWeight: msg.status === 'error' ? 600 : 400
                                                 }}
                                             />
                                         ) : (
                                             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, py: 0.5 }}>
-                                                <CircularProgress size={16} sx={{ color: msg.role === 'user' ? 'white' : '#6366f1' }} />
+                                                <CircularProgress size={16} sx={{ color: msg.role === 'user' ? 'white' : 'var(--n-primary-500)' }} />
                                                 <Typography variant="body2" sx={{ opacity: 0.8 }}>{currentStatus || t('chat.thinking')}</Typography>
                                             </Box>
                                         )}

--- a/app/components/DatabaseBackupModal.tsx
+++ b/app/components/DatabaseBackupModal.tsx
@@ -30,6 +30,7 @@ import ErrorIcon from '@mui/icons-material/Error';
 import WarningIcon from '@mui/icons-material/Warning';
 import StorageIcon from '@mui/icons-material/Storage';
 import TableChartIcon from '@mui/icons-material/TableChart';
+import { getTodayISODate } from '../utils/dateUtils';
 
 interface DatabaseBackupModalProps {
   open: boolean;
@@ -100,7 +101,7 @@ const DatabaseBackupModal: React.FC<DatabaseBackupModalProps> = ({ open, onClose
       const url = URL.createObjectURL(blob);
       const link = document.createElement('a');
       link.href = url;
-      link.download = `backup-${new Date().toISOString().split('T')[0]}.json`;
+      link.download = `backup-${getTodayISODate()}.json`;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);

--- a/app/components/DatabaseErrorScreen.tsx
+++ b/app/components/DatabaseErrorScreen.tsx
@@ -58,7 +58,7 @@ const DatabaseErrorScreen: React.FC<DatabaseErrorScreenProps> = ({ onRetry, isRe
     return (
         <Container>
             <IconWrapper>
-                <StorageIcon sx={{ fontSize: '64px', color: '#ef4444' }} />
+                <StorageIcon sx={{ fontSize: '64px', color: 'var(--n-error)' }} />
             </IconWrapper>
             <Typography variant="h3" sx={{ fontWeight: 700, mb: 2, background: 'linear-gradient(to right, #ef4444, #f87171)', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent' }}>
                 {t('misc:databaseError.title')}

--- a/app/components/DeleteAllTransactionsDialog.tsx
+++ b/app/components/DeleteAllTransactionsDialog.tsx
@@ -17,6 +17,7 @@ import { useTheme } from '@mui/material/styles';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import DeleteSweepIcon from '@mui/icons-material/DeleteSweep';
 import DownloadIcon from '@mui/icons-material/Download';
+import { getTodayISODate } from '../utils/dateUtils';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ErrorIcon from '@mui/icons-material/Error';
 import { useTranslation } from 'react-i18next';
@@ -68,7 +69,7 @@ const DeleteAllTransactionsDialog: React.FC<DeleteAllTransactionsDialogProps> = 
             const url = window.URL.createObjectURL(blob);
             const a = document.createElement('a');
             a.href = url;
-            a.download = `database-backup-${new Date().toISOString().split('T')[0]}.json`;
+            a.download = `database-backup-${getTodayISODate()}.json`;
             document.body.appendChild(a);
             a.click();
             window.URL.revokeObjectURL(url);

--- a/app/components/DeleteConfirmationDialog.tsx
+++ b/app/components/DeleteConfirmationDialog.tsx
@@ -72,7 +72,7 @@ const DeleteConfirmationDialog: React.FC<DeleteConfirmationDialogProps> = ({
                 alignItems: 'center',
                 gap: '12px',
                 fontWeight: 700,
-                color: '#ef4444',
+                color: 'var(--n-error)',
                 paddingBottom: '8px'
             }}>
                 <Box sx={{
@@ -130,7 +130,7 @@ const DeleteConfirmationDialog: React.FC<DeleteConfirmationDialogProps> = ({
                             </Typography>
                             <Typography sx={{
                                 fontSize: '16px',
-                                color: transaction.price < 0 ? '#ef4444' : '#10b981',
+                                color: transaction.price < 0 ? 'var(--n-error)' : 'var(--n-success)',
                                 fontWeight: 700
                             }}>
                                 ₪{formatNumber(Math.abs(transaction.price))}
@@ -153,7 +153,7 @@ const DeleteConfirmationDialog: React.FC<DeleteConfirmationDialogProps> = ({
                                 </Typography>
                                 <Typography sx={{
                                     fontSize: '13px',
-                                    color: '#3b82f6',
+                                    color: 'var(--n-info)',
                                     fontWeight: 600,
                                     backgroundColor: 'rgba(59, 130, 246, 0.1)',
                                     padding: '4px 10px',

--- a/app/components/InsightsView.tsx
+++ b/app/components/InsightsView.tsx
@@ -45,14 +45,14 @@ interface ListResponse {
 }
 
 const TYPE_META: Record<AnomalyType, { icon: React.ReactNode; tone: string }> = {
-    price_hike: { icon: <TrendingUpIcon fontSize="small" />, tone: '#f59e0b' },
-    new_recurring: { icon: <AutorenewIcon fontSize="small" />, tone: '#6366f1' },
+    price_hike: { icon: <TrendingUpIcon fontSize="small" />, tone: 'var(--n-warning)' },
+    new_recurring: { icon: <AutorenewIcon fontSize="small" />, tone: 'var(--n-primary-500)' },
     category_spike: { icon: <LocalFireDepartmentIcon fontSize="small" />, tone: '#ec4899' },
 };
 
 const SEVERITY_TONE: Record<Severity, string> = {
-    high: '#ef4444',
-    medium: '#f59e0b',
+    high: 'var(--n-error)',
+    medium: 'var(--n-warning)',
     low: '#94a3b8',
 };
 
@@ -201,7 +201,7 @@ const InsightsView: React.FC = () => {
                         borderRadius: 'var(--n-radius-lg)',
                     }}
                 >
-                    <CheckIcon sx={{ fontSize: 48, color: '#10b981', mb: 1 }} />
+                    <CheckIcon sx={{ fontSize: 48, color: 'var(--n-success)', mb: 1 }} />
                     <Typography variant="h6" sx={{ mb: 0.5 }}>{t('views:insights.empty')}</Typography>
                     <Typography variant="body2" sx={{
                         color: "text.secondary"

--- a/app/components/ModalHeader.tsx
+++ b/app/components/ModalHeader.tsx
@@ -56,7 +56,7 @@ export default function ModalHeader({ title, onClose, actions, startAction }: Mo
             minHeight: { xs: 40, md: 'auto' },
             '&:hover': {
               background: 'rgba(239, 68, 68, 0.15)',
-              color: '#ef4444',
+              color: 'var(--n-error)',
               transform: 'scale(1.1)',
             }
           }}

--- a/app/components/MonthlySummary.tsx
+++ b/app/components/MonthlySummary.tsx
@@ -1079,7 +1079,7 @@ const MonthlySummary: React.FC = () => {
       <div style={{
         textAlign: 'center',
         padding: '64px',
-        color: '#ef4444'
+        color: 'var(--n-error)'
       }}>
         {t('summary.errorPrefix', { message: error })}
       </div>
@@ -1142,7 +1142,7 @@ const MonthlySummary: React.FC = () => {
             alignItems: 'center',
             minHeight: '300px'
           }}>
-            <CircularProgress size={60} style={{ color: '#3b82f6' }} />
+            <CircularProgress size={60} style={{ color: 'var(--n-info)' }} />
           </div>
         ) : (
           <>
@@ -1218,7 +1218,7 @@ const MonthlySummary: React.FC = () => {
                                 '& .MuiInputBase-root': { bgcolor: theme.palette.background.paper, fontSize: '0.8125rem' }
                               }}
                             />
-                            <IconButton size="small" onClick={handleSaveBudget} sx={{ color: '#10b981', p: 0.5 }}>
+                            <IconButton size="small" onClick={handleSaveBudget} sx={{ color: 'var(--n-success)', p: 0.5 }}>
                               <CheckIcon fontSize="small" />
                             </IconButton>
                           </Box>
@@ -1234,11 +1234,11 @@ const MonthlySummary: React.FC = () => {
                                   flex: 1,
                                   bgcolor: theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.05)',
                                   '& .MuiLinearProgress-bar': {
-                                    bgcolor: totals.card_expenses > budgetLimit ? '#ef4444' : '#10b981'
+                                    bgcolor: totals.card_expenses > budgetLimit ? 'var(--n-error)' : 'var(--n-success)'
                                   }
                                 }}
                               />
-                              <Typography variant="caption" sx={{ fontWeight: 700, color: totals.card_expenses > budgetLimit ? '#ef4444' : '#10b981', fontSize: '0.65rem' }}>
+                              <Typography variant="caption" sx={{ fontWeight: 700, color: totals.card_expenses > budgetLimit ? 'var(--n-error)' : 'var(--n-success)', fontSize: '0.65rem' }}>
                                 {Math.round((totals.card_expenses / budgetLimit) * 100)}%
                               </Typography>
                             </Box>
@@ -1668,7 +1668,7 @@ const MonthlySummary: React.FC = () => {
                               handleNicknameSave(selectedCardForVendor, editingNickname);
                             }
                           }}
-                          sx={{ color: '#10b981' }}
+                          sx={{ color: 'var(--n-success)' }}
                         >
                           <CheckIcon sx={{ fontSize: '18px' }} />
                         </IconButton>
@@ -1700,7 +1700,7 @@ const MonthlySummary: React.FC = () => {
                   <CardVendorIcon vendor={key} size={32} />
                   <span style={{ fontWeight: 500, color: theme.palette.text.primary }}>{config.name}</span>
                   {cardVendorMap[selectedCardForVendor || ''] === key && (
-                    <CheckIcon sx={{ fontSize: '18px', color: '#10b981', ml: 'auto' }} />
+                    <CheckIcon sx={{ fontSize: '18px', color: 'var(--n-success)', ml: 'auto' }} />
                   )}
                 </MenuItem>
               ))}

--- a/app/components/MonthlySummary.tsx
+++ b/app/components/MonthlySummary.tsx
@@ -14,8 +14,6 @@ import { useAI } from '../context/AIContext';
 import CircularProgress from '@mui/material/CircularProgress';
 import IconButton from '@mui/material/IconButton';
 import TextField from '@mui/material/TextField';
-import Snackbar from '@mui/material/Snackbar';
-import Alert from '@mui/material/Alert';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import PageHeader from './PageHeader';
@@ -32,6 +30,8 @@ import Typography from '@mui/material/Typography';
 import { ModalData } from './CategoryDashboard/types';
 import { CardVendorIcon, CARD_VENDORS } from './CardVendorsModal';
 import { useScreenContext } from './Layout';
+import { useSnackbar } from './hooks/useSnackbar';
+import SnackbarFeedback from './SnackbarFeedback';
 import { useDateSelection, DateRangeMode } from '../context/DateSelectionContext';
 import { logger } from '../utils/client-logger';
 import { isBankTransaction, BankCheckTransaction } from '../utils/transactionUtils';
@@ -199,11 +199,10 @@ const MonthlySummary: React.FC = () => {
 
     const cardOwnershipId = cardOwnershipMap[cardLast4];
     if (!cardOwnershipId) {
-      setSnackbar({ open: true, message: t('summary.snackbarMoveCardNoSystemId'), severity: 'error' });
+      showSnackbar(t('summary.snackbarMoveCardNoSystemId'), 'error');
       return;
     }
 
-    // Optimistic update could go here, but for now let's rely on refresh
     try {
       const response = await fetch(`/api/cards/ownerships/${cardOwnershipId}`, {
         method: 'PATCH',
@@ -212,15 +211,14 @@ const MonthlySummary: React.FC = () => {
       });
 
       if (response.ok) {
-        setSnackbar({ open: true, message: t('summary.snackbarCardMoved'), severity: 'success' });
+        showSnackbar(t('summary.snackbarCardMoved'), 'success');
         fetchMonthlySummary(true);
-        // Also refresh vendors to update ownership map if needed, though ID shouldn't change
       } else {
-        setSnackbar({ open: true, message: t('summary.snackbarFailedToMove'), severity: 'error' });
+        showSnackbar(t('summary.snackbarFailedToMove'), 'error');
       }
     } catch (e) {
       logger.error('Move failed', e);
-      setSnackbar({ open: true, message: t('summary.snackbarMoveFailed'), severity: 'error' });
+      showSnackbar(t('summary.snackbarMoveFailed'), 'error');
     }
   };
 
@@ -264,11 +262,7 @@ const MonthlySummary: React.FC = () => {
   // Category editing
 
 
-  const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: 'success' | 'error' }>({
-    open: false,
-    message: '',
-    severity: 'success'
-  });
+  const { snackbar, showSnackbar, hideSnackbar } = useSnackbar();
 
   // Card vendor selection
   const [vendorMenuAnchor, setVendorMenuAnchor] = useState<null | HTMLElement>(null);
@@ -315,7 +309,7 @@ const MonthlySummary: React.FC = () => {
   const handleSaveBudget = async () => {
     const limit = parseFloat(newBudgetLimit);
     if (isNaN(limit) || limit <= 0) {
-      setSnackbar({ open: true, message: t('summary.snackbarInvalidBudget'), severity: 'error' });
+      showSnackbar(t('summary.snackbarInvalidBudget'), 'error');
       return;
     }
 
@@ -329,12 +323,12 @@ const MonthlySummary: React.FC = () => {
       if (res.ok) {
         setBudgetLimit(limit);
         setIsEditingBudget(false);
-        setSnackbar({ open: true, message: t('summary.snackbarBudgetUpdated'), severity: 'success' });
+        showSnackbar(t('summary.snackbarBudgetUpdated'), 'success');
       } else {
         throw new Error('Failed to save');
       }
     } catch (_e) {
-      setSnackbar({ open: true, message: t('summary.snackbarFailedUpdateBudget'), severity: 'error' });
+      showSnackbar(t('summary.snackbarFailedUpdateBudget'), 'error');
     }
   };
 
@@ -431,15 +425,13 @@ const MonthlySummary: React.FC = () => {
           ...prev,
           [selectedCardForVendor]: vendorKey
         }));
-        setSnackbar({
-          open: true,
-          message: t('summary.snackbarCardVendorSet', {
+        showSnackbar(
+          t('summary.snackbarCardVendorSet', {
             last4: selectedCardForVendor,
             vendor: CARD_VENDORS[vendorKey as keyof typeof CARD_VENDORS]?.name || vendorKey
           }),
-          severity: 'success'
-        });
-        // Trigger refresh for other components
+          'success'
+        );
         window.dispatchEvent(new CustomEvent('cardVendorsUpdated'));
       }
     } catch (error) {
@@ -447,11 +439,7 @@ const MonthlySummary: React.FC = () => {
         card: selectedCardForVendor,
         vendor: vendorKey
       });
-      setSnackbar({
-        open: true,
-        message: t('summary.snackbarFailedSaveVendor'),
-        severity: 'error'
-      });
+      showSnackbar(t('summary.snackbarFailedSaveVendor'), 'error');
     }
 
     handleVendorMenuClose();
@@ -476,13 +464,12 @@ const MonthlySummary: React.FC = () => {
           ...prev,
           [last4digits]: nickname
         }));
-        setSnackbar({
-          open: true,
-          message: nickname
+        showSnackbar(
+          nickname
             ? t('summary.snackbarNicknameSet', { nickname })
             : t('summary.snackbarNicknameRemoved'),
-          severity: 'success'
-        });
+          'success'
+        );
         window.dispatchEvent(new CustomEvent('cardVendorsUpdated'));
       }
     } catch (error) {
@@ -490,11 +477,7 @@ const MonthlySummary: React.FC = () => {
         card: last4digits,
         nickname
       });
-      setSnackbar({
-        open: true,
-        message: t('summary.snackbarFailedSaveNickname'),
-        severity: 'error'
-      });
+      showSnackbar(t('summary.snackbarFailedSaveNickname'), 'error');
     }
   };
 
@@ -1789,24 +1772,17 @@ const MonthlySummary: React.FC = () => {
           />
         )}
 
-        <Snackbar
-          open={snackbar.open}
+        <SnackbarFeedback
+          snackbar={snackbar}
+          onClose={hideSnackbar}
           autoHideDuration={5000}
-          onClose={() => setSnackbar({ ...snackbar, open: false })}
           anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
-        >
-          <Alert
-            onClose={() => setSnackbar({ ...snackbar, open: false })}
-            severity={snackbar.severity}
-            sx={{
-              width: "100%",
-              borderRadius: "12px",
-              boxShadow: "0 4px 20px rgba(0, 0, 0, 0.15)"
-            }}
-          >
-            {snackbar.message}
-          </Alert>
-        </Snackbar>
+          alertSx={{
+            width: "100%",
+            borderRadius: "12px",
+            boxShadow: "0 4px 20px rgba(0, 0, 0, 0.15)"
+          }}
+        />
       </Box>
     </div >
   );

--- a/app/components/ProjectionView.tsx
+++ b/app/components/ProjectionView.tsx
@@ -10,11 +10,11 @@ import BlockIcon from '@mui/icons-material/Block';
 import AddIcon from '@mui/icons-material/Add';
 import SaveIcon from '@mui/icons-material/Save';
 import { format } from 'date-fns';
-import Snackbar from '@mui/material/Snackbar';
-import Alert from '@mui/material/Alert';
 import { Dialog, DialogTitle, DialogContent, DialogActions, TextField, Button, MenuItem, Select, FormControl, InputLabel } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useLocale } from '../context/LocaleContext';
+import { useSnackbar, SnackbarState } from './hooks/useSnackbar';
+import SnackbarFeedback from './SnackbarFeedback';
 
 export interface ProjectionData {
     date: string;
@@ -45,8 +45,8 @@ interface ProjectionViewContentProps {
     setIsAddDialogOpen: (open: boolean) => void;
     newRecurring: NewRecurringState;
     setNewRecurring: React.Dispatch<React.SetStateAction<NewRecurringState>>;
-    snackbar: { open: boolean; message: string; severity: 'success' | 'error' };
-    setSnackbar: React.Dispatch<React.SetStateAction<{ open: boolean; message: string; severity: 'success' | 'error' }>>;
+    snackbar: SnackbarState;
+    hideSnackbar: () => void;
     onRefresh: () => void;
     onToggleVisibility: (accountId: number, e: React.MouseEvent) => void;
     onMarkNotRecurring: (name: string, account_number: string) => void;
@@ -65,7 +65,7 @@ export const ProjectionViewContent: React.FC<ProjectionViewContentProps> = ({
     newRecurring,
     setNewRecurring,
     snackbar,
-    setSnackbar,
+    hideSnackbar,
     onRefresh,
     onToggleVisibility: _onToggleVisibility,
     onMarkNotRecurring,
@@ -428,16 +428,14 @@ export const ProjectionViewContent: React.FC<ProjectionViewContentProps> = ({
                     </Box>
                 </Box>
             </Box>
-            <Snackbar
-                open={snackbar.open}
+            <SnackbarFeedback
+                snackbar={snackbar}
+                onClose={hideSnackbar}
                 autoHideDuration={4000}
-                onClose={() => setSnackbar(prev => ({ ...prev, open: false }))}
                 anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-            >
-                <Alert severity={snackbar.severity} sx={{ borderRadius: '12px', fontWeight: 600 }}>
-                    {snackbar.message}
-                </Alert>
-            </Snackbar>
+                alertSx={{ borderRadius: '12px', fontWeight: 600 }}
+                showAlertClose={false}
+            />
             {/* Add Recurring Dialog */}
             <Dialog
                 open={isAddDialogOpen}
@@ -538,11 +536,7 @@ const ProjectionView: React.FC = () => {
         frequency: 'monthly'
     });
 
-    const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: 'success' | 'error' }>({
-        open: false,
-        message: '',
-        severity: 'success'
-    });
+    const { snackbar, showSnackbar, hideSnackbar } = useSnackbar();
 
     const fetchProjection = async () => {
         setLoading(true);
@@ -589,12 +583,12 @@ const ProjectionView: React.FC = () => {
                 }),
             });
             if (!response.ok) throw new Error('Failed to mark as non-recurring');
-            setSnackbar({ open: true, message: t('projection.snackbarExcludedFromProjections', { name }), severity: 'success' });
+            showSnackbar(t('projection.snackbarExcludedFromProjections', { name }), 'success');
             fetchProjection();
             window.dispatchEvent(new CustomEvent('dataRefresh'));
         } catch (err) {
             console.error('Error marking as non-recurring', err);
-            setSnackbar({ open: true, message: t('projection.snackbarFailedExclude'), severity: 'error' });
+            showSnackbar(t('projection.snackbarFailedExclude'), 'error');
         }
     };
 
@@ -621,7 +615,7 @@ const ProjectionView: React.FC = () => {
                 }),
             });
             if (res.ok) {
-                setSnackbar({ open: true, message: t('projection.snackbarRecurringAdded'), severity: 'success' });
+                showSnackbar(t('projection.snackbarRecurringAdded'), 'success');
                 setIsAddDialogOpen(false);
                 setNewRecurring({
                     name: '',
@@ -635,7 +629,7 @@ const ProjectionView: React.FC = () => {
             }
         } catch (err) {
             console.error('Failed to add recurring', err);
-            setSnackbar({ open: true, message: t('projection.snackbarFailedAddRecurring'), severity: 'error' });
+            showSnackbar(t('projection.snackbarFailedAddRecurring'), 'error');
         }
     };
 
@@ -659,7 +653,7 @@ const ProjectionView: React.FC = () => {
             newRecurring={newRecurring}
             setNewRecurring={setNewRecurring}
             snackbar={snackbar}
-            setSnackbar={setSnackbar}
+            hideSnackbar={hideSnackbar}
             onRefresh={fetchProjection}
             onToggleVisibility={handleToggleVisibility}
             onMarkNotRecurring={handleMarkNotRecurring}

--- a/app/components/QuickCategoryModal.tsx
+++ b/app/components/QuickCategoryModal.tsx
@@ -278,7 +278,7 @@ const QuickCategoryModal: React.FC<QuickCategoryModalProps> = ({
                 size="small"
                 sx={{
                   backgroundColor: 'rgba(59, 130, 246, 0.1)',
-                  color: '#3b82f6',
+                  color: 'var(--n-info)',
                   fontWeight: 600
                 }}
               />
@@ -295,7 +295,7 @@ const QuickCategoryModal: React.FC<QuickCategoryModalProps> = ({
             height: 4,
             backgroundColor: 'rgba(59, 130, 246, 0.1)',
             '& .MuiLinearProgress-bar': {
-              backgroundColor: '#3b82f6'
+              backgroundColor: 'var(--n-info)'
             }
           }}
         />
@@ -415,7 +415,7 @@ const QuickCategoryModal: React.FC<QuickCategoryModalProps> = ({
                     size="small"
                     sx={{
                       backgroundColor: 'rgba(59, 130, 246, 0.1)',
-                      color: '#3b82f6',
+                      color: 'var(--n-info)',
                       fontWeight: 600
                     }}
                   />
@@ -424,7 +424,7 @@ const QuickCategoryModal: React.FC<QuickCategoryModalProps> = ({
                     size="small"
                     sx={{
                       backgroundColor: 'rgba(239, 68, 68, 0.1)',
-                      color: '#ef4444',
+                      color: 'var(--n-error)',
                       fontWeight: 600
                     }}
                   />
@@ -462,7 +462,7 @@ const QuickCategoryModal: React.FC<QuickCategoryModalProps> = ({
                           <TableCell sx={{ color: theme.palette.text.secondary, fontSize: '13px' }}>
                             {formatDate(tx.date)}
                           </TableCell>
-                          <TableCell sx={{ color: tx.price < 0 ? '#ef4444' : '#22c55e', fontWeight: 600, fontSize: '13px' }}>
+                          <TableCell sx={{ color: tx.price < 0 ? 'var(--n-error)' : '#22c55e', fontWeight: 600, fontSize: '13px' }}>
                             {formatCurrency(Math.abs(tx.price))}
                           </TableCell>
                           <TableCell sx={{ color: theme.palette.text.secondary, fontSize: '13px' }}>
@@ -491,7 +491,7 @@ const QuickCategoryModal: React.FC<QuickCategoryModalProps> = ({
                                   fontSize: '11px',
                                   marginLeft: tx.installments_total && tx.installments_total > 1 ? '4px' : 0,
                                   backgroundColor: 'rgba(245, 158, 11, 0.1)',
-                                  color: '#f59e0b'
+                                  color: 'var(--n-warning)'
                                 }}
                               />
                             )}
@@ -551,7 +551,7 @@ const QuickCategoryModal: React.FC<QuickCategoryModalProps> = ({
                   onClick={() => handleCategorySelect(category)}
                   disabled={isSaving}
                   sx={{
-                    backgroundColor: categoryColors[category] || '#3b82f6',
+                    backgroundColor: categoryColors[category] || 'var(--n-info)',
                     color: '#fff',
                     textTransform: 'none',
                     fontWeight: 600,
@@ -561,10 +561,10 @@ const QuickCategoryModal: React.FC<QuickCategoryModalProps> = ({
                     minWidth: 'auto',
                     transition: 'all 0.2s ease-in-out',
                     '&:hover': {
-                      backgroundColor: categoryColors[category] || '#3b82f6',
+                      backgroundColor: categoryColors[category] || 'var(--n-info)',
                       filter: 'brightness(1.1)',
                       transform: 'translateY(-2px)',
-                      boxShadow: `0 4px 12px ${categoryColors[category] || '#3b82f6'}40`
+                      boxShadow: `0 4px 12px ${categoryColors[category] || 'var(--n-info)'}40`
                     },
                     '&:active': {
                       transform: 'translateY(0)'

--- a/app/components/RecurringPaymentsView.tsx
+++ b/app/components/RecurringPaymentsView.tsx
@@ -7,9 +7,9 @@ import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import Snackbar from '@mui/material/Snackbar';
-import Alert from '@mui/material/Alert';
 import { useTheme } from '@mui/material/styles';
+import { useSnackbar } from './hooks/useSnackbar';
+import SnackbarFeedback from './SnackbarFeedback';
 
 import RepeatIcon from '@mui/icons-material/Repeat';
 import CreditScoreIcon from '@mui/icons-material/CreditScore';
@@ -126,11 +126,7 @@ const RecurringPaymentsView: React.FC = () => {
     const [categories, setCategories] = useState<string[]>([]);
     const [editingItem, setEditingItem] = useState<{ type: 'installment' | 'recurring', index: number, item: Installment | RecurringTransaction } | null>(null);
     const [editCategory, setEditCategory] = useState('');
-    const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: 'success' | 'error' }>({
-        open: false,
-        message: '',
-        severity: 'success'
-    });
+    const { snackbar, showSnackbar, hideSnackbar } = useSnackbar();
 
     const theme = useTheme();
 
@@ -303,11 +299,11 @@ const RecurringPaymentsView: React.FC = () => {
             const message = result.transactionsUpdated > 1
                 ? t('recurring.snackbarTransactionsUpdated', { count: result.transactionsUpdated, name: editingItem.item.name, category: editCategory })
                 : t('recurring.snackbarCategoryUpdated', { category: editCategory });
-            setSnackbar({ open: true, message, severity: 'success' });
+            showSnackbar(message, 'success');
             window.dispatchEvent(new CustomEvent('dataRefresh'));
         } catch (err) {
             logger.error('Error updating category', err as Error);
-            setSnackbar({ open: true, message: t('recurring.snackbarFailedUpdateCategory'), severity: 'error' });
+            showSnackbar(t('recurring.snackbarFailedUpdateCategory'), 'error');
         } finally {
             setEditingItem(null);
             setEditCategory('');
@@ -330,12 +326,12 @@ const RecurringPaymentsView: React.FC = () => {
                 }),
             });
             if (!response.ok) throw new Error('Failed to mark as non-recurring');
-            setSnackbar({ open: true, message: t('recurring.snackbarMarkedNonRecurring', { name: item.name }), severity: 'success' });
+            showSnackbar(t('recurring.snackbarMarkedNonRecurring', { name: item.name }), 'success');
             fetchData(false);
             window.dispatchEvent(new CustomEvent('dataRefresh'));
         } catch (err) {
             logger.error('Error marking as non-recurring', err as Error);
-            setSnackbar({ open: true, message: t('recurring.snackbarFailedMarkNonRecurring'), severity: 'error' });
+            showSnackbar(t('recurring.snackbarFailedMarkNonRecurring'), 'error');
         }
     };
 
@@ -350,12 +346,12 @@ const RecurringPaymentsView: React.FC = () => {
                 }),
             });
             if (!response.ok) throw new Error('Failed to restore payment');
-            setSnackbar({ open: true, message: t('recurring.snackbarRestored', { name: item.name }), severity: 'success' });
+            showSnackbar(t('recurring.snackbarRestored', { name: item.name }), 'success');
             fetchData(false);
             window.dispatchEvent(new CustomEvent('dataRefresh'));
         } catch (err) {
             logger.error('Error restoring exclusion', err as Error);
-            setSnackbar({ open: true, message: t('recurring.snackbarFailedRestore'), severity: 'error' });
+            showSnackbar(t('recurring.snackbarFailedRestore'), 'error');
         }
     };
 
@@ -823,9 +819,12 @@ const RecurringPaymentsView: React.FC = () => {
                     )}
                 </Box>
             </Box>
-            <Snackbar open={snackbar.open} autoHideDuration={6000} onClose={() => setSnackbar({ ...snackbar, open: false })}>
-                <Alert severity={snackbar.severity} sx={{ borderRadius: '12px', fontWeight: 600 }}>{snackbar.message}</Alert>
-            </Snackbar>
+            <SnackbarFeedback
+                snackbar={snackbar}
+                onClose={hideSnackbar}
+                alertSx={{ borderRadius: '12px', fontWeight: 600 }}
+                showAlertClose={false}
+            />
         </Box>
     );
 };

--- a/app/components/ScrapeModal.tsx
+++ b/app/components/ScrapeModal.tsx
@@ -58,7 +58,7 @@ interface ScraperConfig {
 }
 
 interface ScrapeModalProps {
-  isOpen: boolean;
+  open: boolean;
   onClose: () => void;
   onSuccess?: () => void;
   initialConfig?: ScraperConfig;
@@ -109,7 +109,7 @@ interface RateLimitState {
   startTime: number;
 }
 
-export default function ScrapeModal({ isOpen, onClose, onSuccess, initialConfig }: ScrapeModalProps) {
+export default function ScrapeModal({ open, onClose, onSuccess, initialConfig }: ScrapeModalProps) {
   const { t } = useTranslation('scrape');
   const theme = useTheme();
   const { setIsVaultModalOpen } = useStatus();
@@ -181,7 +181,7 @@ export default function ScrapeModal({ isOpen, onClose, onSuccess, initialConfig 
   }, [initialConfig]);
 
   useEffect(() => {
-    if (isOpen) return;
+    if (open) return;
     queueMicrotask(() => {
       setConfig(initialConfig || defaultConfig);
       setError(null);
@@ -208,7 +208,7 @@ export default function ScrapeModal({ isOpen, onClose, onSuccess, initialConfig 
       abortControllerRef.current.abort();
       abortControllerRef.current = null;
     }
-  }, [isOpen, initialConfig, defaultConfig]);
+  }, [open, initialConfig, defaultConfig]);
 
   const handleConfigChange = (field: string, value: unknown) => {
     if (field.includes('.')) {
@@ -1120,7 +1120,7 @@ export default function ScrapeModal({ isOpen, onClose, onSuccess, initialConfig 
 
   return (
     <Dialog
-      open={isOpen}
+      open={open}
       onClose={handleClose}
       maxWidth="sm"
       fullWidth

--- a/app/components/ScrapeModal.tsx
+++ b/app/components/ScrapeModal.tsx
@@ -676,7 +676,7 @@ export default function ScrapeModal({ open, onClose, onSuccess, initialConfig }:
           }
           label={
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-              <BugReportIcon sx={{ fontSize: 18, color: config.options.showBrowser ? '#3b82f6' : '#9ca3af' }} />
+              <BugReportIcon sx={{ fontSize: 18, color: config.options.showBrowser ? 'var(--n-info)' : '#9ca3af' }} />
               <span>{t('form.debugModeLabel')}</span>
             </Box>
           }
@@ -763,7 +763,7 @@ export default function ScrapeModal({ open, onClose, onSuccess, initialConfig }:
           }
           label={
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-              <BugReportIcon sx={{ fontSize: 18, color: config.options.showBrowser ? '#3b82f6' : '#9ca3af' }} />
+              <BugReportIcon sx={{ fontSize: 18, color: config.options.showBrowser ? 'var(--n-info)' : '#9ca3af' }} />
               <span>{t('form.debugModeLabel')}</span>
             </Box>
           }
@@ -793,11 +793,11 @@ export default function ScrapeModal({ open, onClose, onSuccess, initialConfig }:
           {progress?.step === 'complete' ? (
             <CheckCircleIcon sx={{ color: '#22c55e', mr: 1 }} />
           ) : progress?.success === false ? (
-            <ErrorIcon sx={{ color: '#ef4444', mr: 1 }} />
+            <ErrorIcon sx={{ color: 'var(--n-error)', mr: 1 }} />
           ) : progress?.success === true ? (
             <CheckCircleIcon sx={{ color: '#22c55e', mr: 1, fontSize: 20 }} />
           ) : error ? (
-            <ErrorIcon sx={{ color: '#ef4444', mr: 1 }} />
+            <ErrorIcon sx={{ color: 'var(--n-error)', mr: 1 }} />
           ) : (
             <Box
               sx={{
@@ -836,7 +836,7 @@ export default function ScrapeModal({ open, onClose, onSuccess, initialConfig }:
             mb: 1,
             '& .MuiLinearProgress-bar': {
               borderRadius: 4,
-              backgroundColor: progress?.step === 'complete' ? '#22c55e' : progress?.success === false ? '#ef4444' : '#3b82f6',
+              backgroundColor: progress?.step === 'complete' ? '#22c55e' : progress?.success === false ? 'var(--n-error)' : 'var(--n-info)',
               transition: 'transform 0.3s ease'
             }
           }}
@@ -870,7 +870,7 @@ export default function ScrapeModal({ open, onClose, onSuccess, initialConfig }:
               alignItems: 'center',
               gap: 1.5
             }}>
-              <TimerIcon sx={{ color: '#f59e0b', fontSize: 20 }} />
+              <TimerIcon sx={{ color: 'var(--n-warning)', fontSize: 20 }} />
               <Box sx={{ flex: 1 }}>
                 <Typography variant="body2" sx={{ color: '#d97706', fontWeight: 600 }}>
                   {rateLimitState.message}
@@ -879,7 +879,7 @@ export default function ScrapeModal({ open, onClose, onSuccess, initialConfig }:
                   <Box sx={{
                     width: '100%',
                     height: '100%',
-                    bgcolor: '#f59e0b',
+                    bgcolor: 'var(--n-warning)',
                     animation: `progress-shrink ${rateLimitState.totalSeconds}s linear forwards`,
                     transformOrigin: 'left',
                     '@keyframes progress-shrink': {
@@ -911,7 +911,7 @@ export default function ScrapeModal({ open, onClose, onSuccess, initialConfig }:
                 {step.success === true ? (
                   <CheckCircleIcon sx={{ color: '#22c55e', fontSize: 16, mr: 1 }} />
                 ) : step.success === false ? (
-                  <ErrorIcon sx={{ color: '#ef4444', fontSize: 16, mr: 1 }} />
+                  <ErrorIcon sx={{ color: 'var(--n-error)', fontSize: 16, mr: 1 }} />
                 ) : (
                   <Box sx={{ width: 16, height: 16, mr: 1 }} />
                 )}
@@ -935,7 +935,7 @@ export default function ScrapeModal({ open, onClose, onSuccess, initialConfig }:
               border: `1px solid ${theme.palette.mode === 'dark' ? 'rgba(59, 130, 246, 0.3)' : 'rgba(59, 130, 246, 0.2)'}`,
             }}>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
-                <LockIcon sx={{ color: '#3b82f6', fontSize: 22 }} />
+                <LockIcon sx={{ color: 'var(--n-info)', fontSize: 22 }} />
                 <Typography variant="subtitle2" sx={{ fontWeight: 700, color: theme.palette.text.primary }}>
                   {t('otp.title')}
                 </Typography>
@@ -1005,7 +1005,7 @@ export default function ScrapeModal({ open, onClose, onSuccess, initialConfig }:
               </Box>
 
               {otpSubmitting && (
-                <Typography variant="caption" sx={{ color: '#3b82f6', mt: 1, display: 'block' }}>
+                <Typography variant="caption" sx={{ color: 'var(--n-info)', mt: 1, display: 'block' }}>
                   {t('otp.submitting')}
                 </Typography>
               )}
@@ -1034,7 +1034,7 @@ export default function ScrapeModal({ open, onClose, onSuccess, initialConfig }:
               <Box key={idx} sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5, opacity: idx === 0 ? 1 : 0.7 }}>
                 <Typography variant="caption" sx={{
                   color: log.type === 'httpRequest' ? '#60a5fa' :
-                    log.type === 'httpResponse' ? (log.status && log.status >= 400 ? '#ef4444' : '#22c55e') : '#f59e0b',
+                    log.type === 'httpResponse' ? (log.status && log.status >= 400 ? 'var(--n-error)' : '#22c55e') : 'var(--n-warning)',
                   fontWeight: 'bold',
                   fontSize: '0.7rem',
                   minWidth: 35
@@ -1246,7 +1246,7 @@ export default function ScrapeModal({ open, onClose, onSuccess, initialConfig }:
                     {t('debug.modeActiveDesc')}
                   </Typography>
                   <Box sx={{ mt: 1.5 }}>
-                    <Typography variant="caption" sx={{ color: theme.palette.mode === 'dark' ? '#60a5fa' : '#3b82f6' }}>
+                    <Typography variant="caption" sx={{ color: theme.palette.mode === 'dark' ? '#60a5fa' : 'var(--n-info)' }}>
                       <strong>🖥️ {t('debug.tipLabel')}</strong> {t('debug.tipText')}
                     </Typography>
                   </Box>
@@ -1298,7 +1298,7 @@ export default function ScrapeModal({ open, onClose, onSuccess, initialConfig }:
                 variant="contained"
                 disabled={isLoading}
                 style={{
-                  backgroundColor: '#3b82f6',
+                  backgroundColor: 'var(--n-info)',
                   color: '#fff',
                   padding: '8px 24px',
                   borderRadius: '8px',

--- a/app/components/ScrapeModal.tsx
+++ b/app/components/ScrapeModal.tsx
@@ -33,6 +33,7 @@ import ModalHeader from './ModalHeader';
 import { useTheme } from '@mui/material/styles';
 import { useStatus } from '../context/StatusContext';
 import { BEINLEUMI_GROUP_VENDORS, STANDARD_BANK_VENDORS } from '../utils/constants';
+import { formatISODate, getTodayISODate } from '../utils/dateUtils';
 import dynamic from 'next/dynamic';
 import { ScrapeReportTransaction } from './ScrapeReport';
 const ScrapeReport = dynamic(() => import('./ScrapeReport'), { ssr: false });
@@ -148,12 +149,8 @@ export default function ScrapeModal({ open, onClose, onSuccess, initialConfig }:
       if (interval) clearInterval(interval);
     };
   }, [isLoading]);
-  const todayStr = new Date().toISOString().split('T')[0];
+  const todayStr = getTodayISODate();
   const clampDateString = (value: string) => (value > todayStr ? todayStr : value);
-  const formatDateForInput = (date: Date) => {
-    if (!date || isNaN(date.getTime())) return '';
-    return date.toISOString().split('T')[0];
-  };
   const defaultConfig: ScraperConfig = React.useMemo(() => ({
     options: {
       companyId: 'isracard',
@@ -653,7 +650,7 @@ export default function ScrapeModal({ open, onClose, onSuccess, initialConfig }:
       <TextField
         label={t('form.startDateLabel')}
         type="date"
-        value={formatDateForInput(config.options.startDate)}
+        value={formatISODate(config.options.startDate)}
         onChange={(e) => {
           const v = clampDateString(e.target.value);
           if (v) {
@@ -740,7 +737,7 @@ export default function ScrapeModal({ open, onClose, onSuccess, initialConfig }:
       <TextField
         label={t('form.startDateLabel')}
         type="date"
-        value={formatDateForInput(config.options.startDate)}
+        value={formatISODate(config.options.startDate)}
         onChange={(e) => {
           const v = clampDateString(e.target.value);
           if (v) {

--- a/app/components/ScrapeReport.tsx
+++ b/app/components/ScrapeReport.tsx
@@ -214,7 +214,7 @@ export default function ScrapeReport({ report, summary }: ScrapeReportProps) {
             </td>
             <td style={{ padding: '6px 12px', textAlign: 'right', whiteSpace: 'nowrap' }}>
                 <Typography variant="body2" sx={{
-                    color: tx.amount < 0 ? '#ef4444' : '#22c55e',
+                    color: tx.amount < 0 ? 'var(--n-error)' : '#22c55e',
                     fontSize: '0.8rem',
                     fontWeight: 600
                 }}>

--- a/app/components/SettingsModal.tsx
+++ b/app/components/SettingsModal.tsx
@@ -174,13 +174,13 @@ const StyledAutocomplete = styled(Autocomplete<string, true, false, true>)(({ th
   },
   '& .MuiChip-root': {
     backgroundColor: theme.palette.mode === 'dark' ? 'rgba(16, 185, 129, 0.1)' : 'rgba(16, 185, 129, 0.05)',
-    color: '#10b981',
+    color: 'var(--n-success)',
     borderRadius: '8px',
     height: '28px',
     fontWeight: 500,
     border: `1px solid ${theme.palette.mode === 'dark' ? 'rgba(16, 185, 129, 0.2)' : 'rgba(16, 185, 129, 0.1)'}`,
     '& .MuiChip-deleteIcon': {
-      color: '#10b981',
+      color: 'var(--n-success)',
       fontSize: '16px',
       '&:hover': {
         color: '#059669',
@@ -825,7 +825,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
               </SettingRow>
 
               <Box sx={{ mt: 3, mb: 2, pt: 2, borderTop: `1px solid ${theme.palette.divider}` }}>
-                <Typography variant="subtitle2" sx={{ fontWeight: 600, color: '#f59e0b', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+                <Typography variant="subtitle2" sx={{ fontWeight: 600, color: 'var(--n-warning)', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
                   {t('settings:scraper.vendorSpecific')}
                 </Typography>
               </Box>
@@ -842,10 +842,10 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
                   onChange={(e) => setSettings({ ...settings, isracard_scrape_categories: e.target.checked })}
                   sx={{
                     '& .MuiSwitch-switchBase.Mui-checked': {
-                      color: '#f59e0b',
+                      color: 'var(--n-warning)',
                     },
                     '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
-                      backgroundColor: '#f59e0b',
+                      backgroundColor: 'var(--n-warning)',
                     },
                   }}
                 />
@@ -990,7 +990,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
             {/* WhatsApp Daily Summary */}
             <SettingSection>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
-                <AutoAwesomeIcon sx={{ color: '#10b981' }} />
+                <AutoAwesomeIcon sx={{ color: 'var(--n-success)' }} />
                 <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
                   {t('settings:whatsapp.section')}
                 </Typography>
@@ -1002,10 +1002,10 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
                       width: 8,
                       height: 8,
                       borderRadius: '50%',
-                      bgcolor: whatsappStatus.status === 'READY' || whatsappStatus.status === 'AUTHENTICATED' ? '#10b981' :
-                        whatsappStatus.status === 'DISCONNECTED' ? '#ef4444' : '#f59e0b',
-                      boxShadow: `0 0 8px ${whatsappStatus.status === 'READY' || whatsappStatus.status === 'AUTHENTICATED' ? '#10b981' :
-                        whatsappStatus.status === 'DISCONNECTED' ? '#ef4444' : '#f59e0b'}`
+                      bgcolor: whatsappStatus.status === 'READY' || whatsappStatus.status === 'AUTHENTICATED' ? 'var(--n-success)' :
+                        whatsappStatus.status === 'DISCONNECTED' ? 'var(--n-error)' : 'var(--n-warning)',
+                      boxShadow: `0 0 8px ${whatsappStatus.status === 'READY' || whatsappStatus.status === 'AUTHENTICATED' ? 'var(--n-success)' :
+                        whatsappStatus.status === 'DISCONNECTED' ? 'var(--n-error)' : 'var(--n-warning)'}`
                     }} />
                     <Typography variant="caption" sx={{ fontWeight: 600, color: theme.palette.text.secondary }}>
                       {whatsappStatus.status}
@@ -1053,8 +1053,8 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
               {whatsappStatus.status === 'INITIALIZING' && (
                 <Box sx={{ mb: 3, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1 }}>
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                    <CircularProgress size={20} sx={{ color: '#f59e0b' }} />
-                    <Typography variant="body2" sx={{ color: '#f59e0b' }}>
+                    <CircularProgress size={20} sx={{ color: 'var(--n-warning)' }} />
+                    <Typography variant="body2" sx={{ color: 'var(--n-warning)' }}>
                       {t('settings:whatsapp.generatingQr')}
                     </Typography>
                   </Box>
@@ -1074,8 +1074,8 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
                       onClick={() => handleWhatsAppAction('renewQr')}
                       startIcon={<SyncIcon />}
                       sx={{
-                        borderColor: '#f59e0b',
-                        color: '#f59e0b',
+                        borderColor: 'var(--n-warning)',
+                        color: 'var(--n-warning)',
                         '&:hover': {
                           borderColor: '#d97706',
                           backgroundColor: 'rgba(245, 158, 11, 0.1)',
@@ -1110,10 +1110,10 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
                   onChange={(e) => setSettings({ ...settings, whatsapp_enabled: e.target.checked })}
                   sx={{
                     '& .MuiSwitch-switchBase.Mui-checked': {
-                      color: '#10b981',
+                      color: 'var(--n-success)',
                     },
                     '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
-                      backgroundColor: '#10b981',
+                      backgroundColor: 'var(--n-success)',
                     },
                   }}
                 />
@@ -1131,10 +1131,10 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
                   onChange={(e) => setSettings({ ...settings, whatsapp_notify_on_restart: e.target.checked })}
                   sx={{
                     '& .MuiSwitch-switchBase.Mui-checked': {
-                      color: '#10b981',
+                      color: 'var(--n-success)',
                     },
                     '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
-                      backgroundColor: '#10b981',
+                      backgroundColor: 'var(--n-success)',
                     },
                   }}
                 />
@@ -1276,7 +1276,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
                       maxHeight: '300px',
                       overflow: 'auto'
                     }}>
-                      <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1, color: '#10b981' }}>
+                      <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1, color: 'var(--n-success)' }}>
                         {t('settings:whatsapp.generatedMessage')}
                       </Typography>
                       <Typography
@@ -1717,7 +1717,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
                           borderColor: '#818cf8',
                           color: '#818cf8',
                           '&:hover': {
-                            borderColor: '#6366f1',
+                            borderColor: 'var(--n-primary-500)',
                             backgroundColor: 'rgba(99, 102, 241, 0.1)',
                           },
                         }}

--- a/app/components/SnackbarFeedback.tsx
+++ b/app/components/SnackbarFeedback.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import Snackbar, { SnackbarProps } from '@mui/material/Snackbar';
+import Alert, { AlertProps } from '@mui/material/Alert';
+import { SnackbarState } from './hooks/useSnackbar';
+
+interface SnackbarFeedbackProps {
+    snackbar: SnackbarState;
+    onClose: () => void;
+    autoHideDuration?: number;
+    anchorOrigin?: SnackbarProps['anchorOrigin'];
+    alertSx?: AlertProps['sx'];
+    showAlertClose?: boolean;
+}
+
+const SnackbarFeedback: React.FC<SnackbarFeedbackProps> = ({
+    snackbar,
+    onClose,
+    autoHideDuration = 6000,
+    anchorOrigin,
+    alertSx,
+    showAlertClose = true,
+}) => (
+    <Snackbar
+        open={snackbar.open}
+        autoHideDuration={autoHideDuration}
+        onClose={onClose}
+        anchorOrigin={anchorOrigin}
+    >
+        <Alert
+            severity={snackbar.severity}
+            onClose={showAlertClose ? onClose : undefined}
+            sx={alertSx}
+        >
+            {snackbar.message}
+        </Alert>
+    </Snackbar>
+);
+
+export default SnackbarFeedback;

--- a/app/components/SyncHistoryModal.tsx
+++ b/app/components/SyncHistoryModal.tsx
@@ -104,7 +104,7 @@ export default function SyncHistoryModal({ open, onClose }: SyncHistoryModalProp
 
     const getStatusIcon = (status: string) => {
         if (status === 'success') return <CheckCircleIcon sx={{ color: '#22c55e', fontSize: 20 }} />;
-        if (status === 'error') return <ErrorIcon sx={{ color: '#ef4444', fontSize: 20 }} />;
+        if (status === 'error') return <ErrorIcon sx={{ color: 'var(--n-error)', fontSize: 20 }} />;
         return <CircularProgress size={20} />;
     };
 

--- a/app/components/SyncHistoryModal.tsx
+++ b/app/components/SyncHistoryModal.tsx
@@ -29,7 +29,7 @@ interface SyncReport {
 }
 
 interface SyncHistoryModalProps {
-    isOpen: boolean;
+    open: boolean;
     onClose: () => void;
 }
 
@@ -44,7 +44,7 @@ interface SyncEvent {
     duration_seconds?: number;
 }
 
-export default function SyncHistoryModal({ isOpen, onClose }: SyncHistoryModalProps) {
+export default function SyncHistoryModal({ open, onClose }: SyncHistoryModalProps) {
     const theme = useTheme();
     const { t } = useTranslation(['sync', 'common']);
     const { locale } = useLocale();
@@ -71,12 +71,12 @@ export default function SyncHistoryModal({ isOpen, onClose }: SyncHistoryModalPr
     };
 
     useEffect(() => {
-        if (!isOpen) return;
+        if (!open) return;
         queueMicrotask(() => {
             fetchEvents();
             setSelectedEvent(null);
         });
-    }, [isOpen]);
+    }, [open]);
 
     const handleSelectEvent = async (event: SyncEvent) => {
         setSelectedEvent(event);
@@ -110,7 +110,7 @@ export default function SyncHistoryModal({ isOpen, onClose }: SyncHistoryModalPr
 
     return (
         <Dialog
-            open={isOpen}
+            open={open}
             onClose={onClose}
             maxWidth="md"
             fullWidth

--- a/app/components/SyncStatusModal.tsx
+++ b/app/components/SyncStatusModal.tsx
@@ -32,6 +32,7 @@ import CloudOffIcon from '@mui/icons-material/CloudOff';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import TimerIcon from '@mui/icons-material/Timer';
 import { BEINLEUMI_GROUP_VENDORS, BANK_VENDORS } from '../utils/constants';
+import { formatISODate } from '../utils/dateUtils';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import dynamic from 'next/dynamic';
@@ -508,13 +509,13 @@ const SyncStatusModal: React.FC<SyncStatusModalProps> = ({ open, onClose, width,
       const startDate = lastDate ? new Date(lastDate) : new Date();
       const daysBack = status?.settings?.daysBack || 30;
       startDate.setDate(startDate.getDate() - daysBack);
-      const computed = startDate.toISOString().split('T')[0];
+      const computed = formatISODate(startDate);
       setSyncOptionsStartDate(computed);
       setSyncOptionsDateError(validateSyncDate(computed));
     } catch {
       const fallback = new Date();
       fallback.setDate(fallback.getDate() - 30);
-      const computed = fallback.toISOString().split('T')[0];
+      const computed = formatISODate(fallback);
       setSyncOptionsStartDate(computed);
       setSyncOptionsDateError(validateSyncDate(computed));
     } finally {
@@ -891,7 +892,7 @@ const SyncStatusModal: React.FC<SyncStatusModalProps> = ({ open, onClose, width,
           const startDate = lastDate ? new Date(lastDate) : new Date();
           const daysBack = status?.settings?.daysBack || 30;
           startDate.setDate(startDate.getDate() - daysBack);
-          computedStartDate = startDate.toISOString().split('T')[0];
+          computedStartDate = formatISODate(startDate);
         }
 
         const credentials = prepareCredentials(account, account.vendor);

--- a/app/components/SyncStatusModal.tsx
+++ b/app/components/SyncStatusModal.tsx
@@ -1139,21 +1139,21 @@ const SyncStatusModal: React.FC<SyncStatusModalProps> = ({ open, onClose, width,
         return {
           icon: <ErrorIcon sx={{ fontSize: 48 }} />,
           label: t('health.error.label'),
-          color: '#ef4444',
+          color: 'var(--n-error)',
           description: t('health.error.description')
         };
       case 'stale':
         return {
           icon: <WarningIcon sx={{ fontSize: 48 }} />,
           label: t('health.stale.label'),
-          color: '#f59e0b',
+          color: 'var(--n-warning)',
           description: t('health.stale.description')
         };
       case 'outdated':
         return {
           icon: <WarningIcon sx={{ fontSize: 48 }} />,
           label: t('health.outdated.label'),
-          color: '#f59e0b',
+          color: 'var(--n-warning)',
           description: t('health.outdated.description')
         };
       case 'never_synced':
@@ -1299,7 +1299,7 @@ const SyncStatusModal: React.FC<SyncStatusModalProps> = ({ open, onClose, width,
                   {t('options.showBrowser')}
                 </Typography>
                 {pendingSyncRequest.vendor === 'hapoalim' && (
-                  <Typography variant="caption" sx={{ color: '#3b82f6', fontSize: '10px' }}>
+                  <Typography variant="caption" sx={{ color: 'var(--n-info)', fontSize: '10px' }}>
                     {t('options.showBrowserHapoalimHint')}
                   </Typography>
                 )}
@@ -1401,7 +1401,7 @@ const SyncStatusModal: React.FC<SyncStatusModalProps> = ({ open, onClose, width,
                             <Box sx={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: '#fff' }} />
                           </Box>
                         ) : isFailed ? (
-                          <ErrorIcon sx={{ fontSize: 18, color: '#ef4444' }} />
+                          <ErrorIcon sx={{ fontSize: 18, color: 'var(--n-error)' }} />
                         ) : isActive ? (
                           <SyncIcon sx={{ fontSize: 18, color: '#60a5fa', animation: `${spin} 2s linear infinite` }} />
                         ) : (
@@ -1410,7 +1410,7 @@ const SyncStatusModal: React.FC<SyncStatusModalProps> = ({ open, onClose, width,
 
                         <Box sx={{ flex: 1 }}>
                           <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                            <Typography variant="body2" sx={{ fontWeight: isActive ? 600 : 500, color: isActive ? '#60a5fa' : isCompleted ? '#22c55e' : isFailed ? '#ef4444' : 'text.secondary' }}>
+                            <Typography variant="body2" sx={{ fontWeight: isActive ? 600 : 500, color: isActive ? '#60a5fa' : isCompleted ? '#22c55e' : isFailed ? 'var(--n-error)' : 'text.secondary' }}>
                               {item.accountName}
                             </Typography>
                             {isCompleted && (
@@ -1463,8 +1463,8 @@ const SyncStatusModal: React.FC<SyncStatusModalProps> = ({ open, onClose, width,
                                   border: '1px solid rgba(59, 130, 246, 0.3)'
                                 }}>
                                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-                                    <LockIcon sx={{ fontSize: 16, color: '#3b82f6' }} />
-                                    <Typography variant="caption" sx={{ fontWeight: 600, color: '#3b82f6' }}>
+                                    <LockIcon sx={{ fontSize: 16, color: 'var(--n-info)' }} />
+                                    <Typography variant="caption" sx={{ fontWeight: 600, color: 'var(--n-info)' }}>
                                       {t('progress.twoFactorRequired')}
                                     </Typography>
                                   </Box>
@@ -1501,7 +1501,7 @@ const SyncStatusModal: React.FC<SyncStatusModalProps> = ({ open, onClose, width,
                                       sx={{
                                         minWidth: 32,
                                         p: 0,
-                                        background: '#3b82f6',
+                                        background: 'var(--n-info)',
                                         '&:hover': { background: '#2563eb' }
                                       }}
                                     >
@@ -1509,7 +1509,7 @@ const SyncStatusModal: React.FC<SyncStatusModalProps> = ({ open, onClose, width,
                                     </Button>
                                   </Box>
                                   {otpError && (
-                                    <Typography variant="caption" sx={{ color: '#ef4444', mt: 0.5, display: 'block' }}>
+                                    <Typography variant="caption" sx={{ color: 'var(--n-error)', mt: 0.5, display: 'block' }}>
                                       {otpError}
                                     </Typography>
                                   )}
@@ -1542,7 +1542,7 @@ const SyncStatusModal: React.FC<SyncStatusModalProps> = ({ open, onClose, width,
                           )}
 
                           {isFailed && item.error && (
-                            <Typography variant="caption" sx={{ color: '#ef4444', display: 'block', mt: 0.5, fontSize: '10px' }}>
+                            <Typography variant="caption" sx={{ color: 'var(--n-error)', display: 'block', mt: 0.5, fontSize: '10px' }}>
                               {item.error}
                             </Typography>
                           )}
@@ -1886,8 +1886,8 @@ const SyncStatusModal: React.FC<SyncStatusModalProps> = ({ open, onClose, width,
         <Box sx={{ p: 3 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-              <ErrorIcon sx={{ color: '#ef4444', fontSize: 28 }} />
-              <Typography variant="h6" sx={{ fontWeight: 600, color: '#ef4444' }}>
+              <ErrorIcon sx={{ color: 'var(--n-error)', fontSize: 28 }} />
+              <Typography variant="h6" sx={{ fontWeight: 600, color: 'var(--n-error)' }}>
                 {t('errorDetails.title')}
               </Typography>
             </Box>

--- a/app/components/hooks/useSnackbar.ts
+++ b/app/components/hooks/useSnackbar.ts
@@ -1,0 +1,36 @@
+import { useCallback, useState } from 'react';
+
+export type SnackbarSeverity = 'success' | 'error' | 'info' | 'warning';
+
+export interface SnackbarState<S extends SnackbarSeverity = SnackbarSeverity> {
+    open: boolean;
+    message: string;
+    severity: S;
+}
+
+export interface UseSnackbarResult<S extends SnackbarSeverity = SnackbarSeverity> {
+    snackbar: SnackbarState<S>;
+    showSnackbar: (message: string, severity?: S) => void;
+    hideSnackbar: () => void;
+}
+
+const DEFAULT_STATE: SnackbarState = { open: false, message: '', severity: 'success' };
+
+export function useSnackbar<S extends SnackbarSeverity = 'success' | 'error'>(
+    initial?: Partial<SnackbarState<S>>
+): UseSnackbarResult<S> {
+    const [snackbar, setSnackbar] = useState<SnackbarState<S>>({
+        ...(DEFAULT_STATE as SnackbarState<S>),
+        ...initial,
+    });
+
+    const showSnackbar = useCallback((message: string, severity: S = 'success' as S) => {
+        setSnackbar({ open: true, message, severity });
+    }, []);
+
+    const hideSnackbar = useCallback(() => {
+        setSnackbar(prev => ({ ...prev, open: false }));
+    }, []);
+
+    return { snackbar, showSnackbar, hideSnackbar };
+}

--- a/app/components/menu.tsx
+++ b/app/components/menu.tsx
@@ -467,7 +467,7 @@ function ResponsiveAppBar({ currentView = 'summary', onViewChange }: ResponsiveA
         {drawerContent(false)}
       </Drawer>
       <ScrapeModal
-        isOpen={isScrapeModalOpen}
+        open={isScrapeModalOpen}
         onClose={() => setIsScrapeModalOpen(false)}
         onSuccess={handleScrapeSuccess}
       />
@@ -480,7 +480,7 @@ function ResponsiveAppBar({ currentView = 'summary', onViewChange }: ResponsiveA
         }}
       />
       <CardVendorsModal
-        isOpen={isCardVendorsOpen}
+        open={isCardVendorsOpen}
         onClose={() => setIsCardVendorsOpen(false)}
       />
       <DatabaseBackupModal

--- a/app/pages/api/ping.js
+++ b/app/pages/api/ping.js
@@ -1,20 +1,9 @@
-import { getDB } from "./db";
-import logger from '../../utils/logger.js';
+import { withDB } from "../../utils/withDB";
 
-export default async function handler(req, res) {
+export default withDB(async (req, res, client) => {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
-
-  const client = await getDB();
-  try {
-    // Simple query to check connection
-    await client.query('SELECT 1');
-    res.status(200).json({ status: 'ok' });
-  } catch (error) {
-    logger.error({ error: error.message, stack: error.stack }, 'Ping check failed');
-    res.status(500).json({ status: 'error', error: 'Database connection failed' });
-  } finally {
-    client.release();
-  }
-} 
+  await client.query('SELECT 1');
+  res.status(200).json({ status: 'ok' });
+});

--- a/app/pages/api/scrapers/status.js
+++ b/app/pages/api/scrapers/status.js
@@ -1,154 +1,137 @@
-import { getDB } from '../db';
-import logger from '../../../utils/logger.js';
+import { withDB } from '../../../utils/withDB';
 
-export default async function handler(req, res) {
+export default withDB(async (req, res, client) => {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  const client = await getDB();
-
   const minimal = req.query.minimal === 'true';
 
-  try {
-    // Get sync settings
-    const settingsResult = await client.query(
-      `SELECT key, value FROM app_settings WHERE key IN ('sync_enabled', 'sync_hour', 'sync_days_back')`
-    );
+  const settingsResult = await client.query(
+    `SELECT key, value FROM app_settings WHERE key IN ('sync_enabled', 'sync_hour', 'sync_days_back')`
+  );
 
-    const settings = {};
-    for (const row of settingsResult.rows) {
-      settings[row.key] = row.value;
-    }
-
-    // Get active accounts count
-    const accountsResult = await client.query(
-      `SELECT COUNT(*) as count FROM vendor_credentials WHERE is_active = true`
-    );
-    const activeAccounts = parseInt(accountsResult.rows[0].count, 10);
-
-    // Get the most recent scrape event
-    const latestScrapeResult = await client.query(`
-      SELECT 
-        id,
-        triggered_by,
-        vendor,
-        start_date,
-        status,
-        message,
-        CASE 
-          WHEN created_at IS NOT NULL 
-          THEN to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')
-          ELSE NULL
-        END as created_at,
-        duration_seconds
-      FROM scrape_events
-      ORDER BY created_at DESC
-      LIMIT 1
-    `);
-    const latestScrape = latestScrapeResult.rows[0] || null;
-
-    // Get last synced time for each active account
-    const lastSyncedResult = await client.query(`
-      SELECT 
-        id,
-        nickname,
-        vendor,
-        CASE 
-          WHEN last_synced_at IS NOT NULL 
-          THEN to_char(last_synced_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')
-          ELSE NULL
-        END as last_synced_at
-      FROM vendor_credentials
-      WHERE is_active = true
-      ORDER BY last_synced_at DESC NULLS LAST
-    `);
-    const accountSyncStatus = lastSyncedResult.rows;
-
-    // Calculate overall sync health
-    const now = new Date();
-    const intervalHours = 24; // Implicit daily interval
-    let syncHealth = 'unknown';
-
-    if (latestScrape && latestScrape.created_at) {
-      const lastSyncTime = new Date(latestScrape.created_at);
-      const hoursSinceSync = (now.getTime() - lastSyncTime.getTime()) / (1000 * 60 * 60);
-
-      if (latestScrape.status === 'completed' || latestScrape.status === 'success') {
-        if (hoursSinceSync < intervalHours) {
-          syncHealth = 'healthy';
-        } else if (hoursSinceSync < intervalHours * 2) {
-          syncHealth = 'stale';
-        } else {
-          syncHealth = 'outdated';
-        }
-      } else if (latestScrape.status === 'started') {
-        if (hoursSinceSync > 0.33) {
-          syncHealth = 'error';
-          latestScrape.message = 'Sync timed out or process crashed';
-        } else {
-          syncHealth = 'syncing';
-        }
-      } else if (latestScrape.status === 'failed' || latestScrape.status === 'error') {
-        syncHealth = 'error';
-      } else if (latestScrape.status === 'cancelled') {
-        syncHealth = 'healthy';
-      }
-    } else if (activeAccounts === 0) {
-      syncHealth = 'no_accounts';
-    } else {
-      syncHealth = 'never_synced';
-    }
-
-    // Prepare response
-    const response = {
-      syncHealth,
-      settings: {
-        enabled: settings.sync_enabled === true || settings.sync_enabled === 'true',
-        syncHour: parseInt(settings.sync_hour, 10) || 3,
-        daysBack: parseInt(settings.sync_days_back, 10) || 30
-      },
-      activeAccounts,
-      latestScrape,
-      summary: {
-        oldest_sync_at: accountSyncStatus.length > 0 ? accountSyncStatus[accountSyncStatus.length - 1].last_synced_at : null,
-        has_never_synced: accountSyncStatus.some(a => !a.last_synced_at)
-      }
-    };
-
-    if (minimal) {
-      return res.status(200).json(response);
-    }
-
-    // Detailed info for non-minimal requests
-    const historyResult = await client.query(`
-      SELECT 
-        id,
-        triggered_by,
-        vendor,
-        start_date,
-        status,
-        message,
-        CASE 
-          WHEN created_at IS NOT NULL 
-          THEN to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')
-          ELSE NULL
-        END as created_at,
-        duration_seconds
-      FROM scrape_events
-      ORDER BY created_at DESC
-      LIMIT 10
-    `);
-
-    res.status(200).json({
-      ...response,
-      history: historyResult.rows,
-      accountSyncStatus
-    });
-  } catch (error) {
-    logger.error({ error: error.message, stack: error.stack }, 'Sync status error');
-    res.status(500).json({ error: 'Internal Server Error' });
-  } finally {
-    client.release();
+  const settings = {};
+  for (const row of settingsResult.rows) {
+    settings[row.key] = row.value;
   }
-}
+
+  const accountsResult = await client.query(
+    `SELECT COUNT(*) as count FROM vendor_credentials WHERE is_active = true`
+  );
+  const activeAccounts = parseInt(accountsResult.rows[0].count, 10);
+
+  const latestScrapeResult = await client.query(`
+    SELECT
+      id,
+      triggered_by,
+      vendor,
+      start_date,
+      status,
+      message,
+      CASE
+        WHEN created_at IS NOT NULL
+        THEN to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')
+        ELSE NULL
+      END as created_at,
+      duration_seconds
+    FROM scrape_events
+    ORDER BY created_at DESC
+    LIMIT 1
+  `);
+  const latestScrape = latestScrapeResult.rows[0] || null;
+
+  const lastSyncedResult = await client.query(`
+    SELECT
+      id,
+      nickname,
+      vendor,
+      CASE
+        WHEN last_synced_at IS NOT NULL
+        THEN to_char(last_synced_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')
+        ELSE NULL
+      END as last_synced_at
+    FROM vendor_credentials
+    WHERE is_active = true
+    ORDER BY last_synced_at DESC NULLS LAST
+  `);
+  const accountSyncStatus = lastSyncedResult.rows;
+
+  const now = new Date();
+  const intervalHours = 24;
+  let syncHealth = 'unknown';
+
+  if (latestScrape && latestScrape.created_at) {
+    const lastSyncTime = new Date(latestScrape.created_at);
+    const hoursSinceSync = (now.getTime() - lastSyncTime.getTime()) / (1000 * 60 * 60);
+
+    if (latestScrape.status === 'completed' || latestScrape.status === 'success') {
+      if (hoursSinceSync < intervalHours) {
+        syncHealth = 'healthy';
+      } else if (hoursSinceSync < intervalHours * 2) {
+        syncHealth = 'stale';
+      } else {
+        syncHealth = 'outdated';
+      }
+    } else if (latestScrape.status === 'started') {
+      if (hoursSinceSync > 0.33) {
+        syncHealth = 'error';
+        latestScrape.message = 'Sync timed out or process crashed';
+      } else {
+        syncHealth = 'syncing';
+      }
+    } else if (latestScrape.status === 'failed' || latestScrape.status === 'error') {
+      syncHealth = 'error';
+    } else if (latestScrape.status === 'cancelled') {
+      syncHealth = 'healthy';
+    }
+  } else if (activeAccounts === 0) {
+    syncHealth = 'no_accounts';
+  } else {
+    syncHealth = 'never_synced';
+  }
+
+  const response = {
+    syncHealth,
+    settings: {
+      enabled: settings.sync_enabled === true || settings.sync_enabled === 'true',
+      syncHour: parseInt(settings.sync_hour, 10) || 3,
+      daysBack: parseInt(settings.sync_days_back, 10) || 30
+    },
+    activeAccounts,
+    latestScrape,
+    summary: {
+      oldest_sync_at: accountSyncStatus.length > 0 ? accountSyncStatus[accountSyncStatus.length - 1].last_synced_at : null,
+      has_never_synced: accountSyncStatus.some(a => !a.last_synced_at)
+    }
+  };
+
+  if (minimal) {
+    return res.status(200).json(response);
+  }
+
+  const historyResult = await client.query(`
+    SELECT
+      id,
+      triggered_by,
+      vendor,
+      start_date,
+      status,
+      message,
+      CASE
+        WHEN created_at IS NOT NULL
+        THEN to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')
+        ELSE NULL
+      END as created_at,
+      duration_seconds
+    FROM scrape_events
+    ORDER BY created_at DESC
+    LIMIT 10
+  `);
+
+  res.status(200).json({
+    ...response,
+    history: historyResult.rows,
+    accountSyncStatus
+  });
+});

--- a/app/pages/api/scrapers/stop.js
+++ b/app/pages/api/scrapers/stop.js
@@ -1,13 +1,12 @@
-import { getDB } from '../db';
 import logger from '../../../utils/logger.js';
+import { withDB } from '../../../utils/withDB';
 import { stopAllScrapers } from '../utils/scraperUtils';
 
-export default async function handler(req, res) {
+export default withDB(async (req, res, client) => {
     if (req.method !== 'POST') {
         return res.status(405).json({ message: 'Method not allowed' });
     }
 
-    const client = await getDB();
     try {
         await stopAllScrapers(client);
         res.status(200).json({
@@ -20,7 +19,5 @@ export default async function handler(req, res) {
             success: false,
             message: 'Failed to stop scrapers.'
         });
-    } finally {
-        client.release();
     }
-}
+});

--- a/app/stories/ProjectionView.stories.tsx
+++ b/app/stories/ProjectionView.stories.tsx
@@ -29,7 +29,7 @@ const meta = {
         setSelectedAccount: (_val) => { },
         setIsAddDialogOpen: (_open) => { },
         setNewRecurring: () => { },
-        setSnackbar: () => { },
+        hideSnackbar: () => { },
     },
 } satisfies Meta<typeof ProjectionViewContent>;
 

--- a/app/tests/scraper_endpoints.test.ts
+++ b/app/tests/scraper_endpoints.test.ts
@@ -14,7 +14,13 @@ vi.mock('../pages/api/utils/scraperUtils', () => ({
 
 vi.mock('../pages/api/utils/encryption', () => ({
     decrypt: vi.fn(),
-    encrypt: vi.fn()
+    encrypt: vi.fn(),
+    VaultLockedError: class VaultLockedError extends Error {
+        constructor(message?: string) {
+            super(message);
+            this.name = 'VaultLockedError';
+        }
+    }
 }));
 
 import { getDB } from '../pages/api/db';

--- a/app/tests/withDB.test.ts
+++ b/app/tests/withDB.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../pages/api/db', () => ({
+    getDB: vi.fn()
+}));
+
+vi.mock('../utils/logger.js', () => ({
+    default: { info: vi.fn(), error: vi.fn(), warn: vi.fn() }
+}));
+
+import { getDB } from '../pages/api/db';
+import { withDB } from '../utils/withDB';
+import { VaultLockedError } from '../pages/api/utils/encryption';
+
+describe('withDB', () => {
+    let mockClient: { query: ReturnType<typeof vi.fn>; release: ReturnType<typeof vi.fn> };
+    let mockRes: {
+        status: ReturnType<typeof vi.fn>;
+        json: ReturnType<typeof vi.fn>;
+        setHeader: ReturnType<typeof vi.fn>;
+        headersSent: boolean;
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockClient = { query: vi.fn(), release: vi.fn() };
+        (getDB as any).mockResolvedValue(mockClient);
+        mockRes = {
+            status: vi.fn().mockReturnThis(),
+            json: vi.fn().mockReturnThis(),
+            setHeader: vi.fn(),
+            headersSent: false,
+        };
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('passes the client to the handler', async () => {
+        const handler = vi.fn(async (_req: any, res: any, _client: any) => {
+            res.status(200).json({ ok: true });
+        });
+        const wrapped = withDB(handler);
+
+        await wrapped({ method: 'GET' } as any, mockRes as any);
+
+        expect(handler).toHaveBeenCalledWith(
+            expect.objectContaining({ method: 'GET' }),
+            mockRes,
+            mockClient
+        );
+        expect(mockRes.status).toHaveBeenCalledWith(200);
+    });
+
+    it('releases the client on success', async () => {
+        const handler = async (_req: any, res: any) => {
+            res.status(200).json({ ok: true });
+        };
+        await withDB(handler)({} as any, mockRes as any);
+        expect(mockClient.release).toHaveBeenCalledTimes(1);
+    });
+
+    it('releases the client on error', async () => {
+        const handler = async () => {
+            throw new Error('boom');
+        };
+        await withDB(handler)({} as any, mockRes as any);
+        expect(mockClient.release).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns 500 when the handler throws', async () => {
+        const handler = async () => {
+            throw new Error('boom');
+        };
+        await withDB(handler)({} as any, mockRes as any);
+        expect(mockRes.status).toHaveBeenCalledWith(500);
+        expect(mockRes.json).toHaveBeenCalledWith({ error: 'Internal Server Error' });
+    });
+
+    it('returns 401 with VAULT_LOCKED type for VaultLockedError', async () => {
+        const vaultError = new VaultLockedError();
+        const handler = async () => {
+            throw vaultError;
+        };
+        await withDB(handler)({} as any, mockRes as any);
+        expect(mockRes.status).toHaveBeenCalledWith(401);
+        expect(mockRes.json).toHaveBeenCalledWith({
+            error: vaultError.message,
+            type: 'VAULT_LOCKED'
+        });
+    });
+
+    it('does not send another response when headers are already sent', async () => {
+        const handler = async (_req: any, res: any) => {
+            res.headersSent = true;
+            throw new Error('boom after stream started');
+        };
+        await withDB(handler)({} as any, mockRes as any);
+        expect(mockRes.status).not.toHaveBeenCalled();
+        expect(mockClient.release).toHaveBeenCalledTimes(1);
+    });
+});

--- a/app/utils/withDB.ts
+++ b/app/utils/withDB.ts
@@ -1,0 +1,34 @@
+import { getDB } from "../pages/api/db";
+import logger from './logger.js';
+import { VaultLockedError } from "../pages/api/utils/encryption";
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- Loose typing intentional: handler is consumed by both production Next API routes and tests passing partial mocks */
+
+type DBClient = {
+    query: (...args: any[]) => Promise<any>;
+    release: () => void;
+};
+
+type HandlerFn = (req: any, res: any, client: DBClient) => Promise<unknown> | unknown;
+
+export function withDB(handler: HandlerFn) {
+    return async function wrappedHandler(req: any, res: any) {
+        const client = await getDB();
+        try {
+            await handler(req, res, client);
+        } catch (error: any) {
+            if (error instanceof VaultLockedError) {
+                if (!res.headersSent) {
+                    return res.status(401).json({ error: error.message, type: 'VAULT_LOCKED' });
+                }
+                return;
+            }
+            logger.error({ error: error.message, stack: error.stack }, "API handler error");
+            if (!res.headersSent) {
+                res.status(500).json({ error: "Internal Server Error" });
+            }
+        } finally {
+            client.release();
+        }
+    };
+}


### PR DESCRIPTION
## Summary

Six-commit refactor branch targeting code duplication and coding-standards inconsistencies, focused on "opposite pair" patterns (show/hide, open/close, encrypt/decrypt, etc.).

| # | Commit | What changed |
|---|---|---|
| 1 | `useSnackbar` + `withDB` | New `useSnackbar()` hook + `<SnackbarFeedback>` component replace 6 copies of the snackbar useState/Snackbar/Alert pattern. New `withDB()` wrapper replaces `getDB`+try/finally+release boilerplate in `ping`, `scrapers/status`, `scrapers/stop`. +6 unit tests for `withDB`. |
| 2 | ProjectionView hook | Last snackbar duplication; child prop signature simplified from `{snackbar,setSnackbar}` to `{snackbar,hideSnackbar}`. |
| 3 | Modal `isOpen` → `open` | 4 modals (ScrapeModal, CardVendorsModal, AccountsModal, SyncHistoryModal) standardized on MUI's `open` prop. 4 call sites updated. |
| 4 | `formatISODate` consolidation | Replace `new Date().toISOString().split('T')[0]` in 4 client-side components with the existing `formatISODate`/`getTodayISODate` helpers. Fixes a latent midnight off-by-one bug for non-UTC users (the original pattern mixed local-time arithmetic with UTC formatting). |
| 5–6 | Hex → CSS tokens | 128 hex literals across 19 components swapped for `var(--n-error|success|info|warning|primary-500)`. Only exact-token matches (`#ef4444`/`#10b981`/`#3b82f6`/`#f59e0b`/`#6366f1`) replaced — non-matching hex values left alone to avoid silent visual shifts. `NumberEasterEgg` (canvas-confetti) and `DesignSystemShowcase` (literally demos the tokens) intentionally skipped. |

Net: ~500 LOC of snackbar duplication consolidated, ~150 LOC of DB boilerplate removed, ~128 hex literals migrated to design tokens.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 759/759 tests pass (753 existing + 6 new `withDB` tests)
- [ ] Manual smoke test of snackbars firing across MonthlySummary / BreakdownView / RecurringPaymentsView / CardVendorsModal / ProjectionView / ExpensesModal / TransactionsTable
- [ ] Visual spot-check that themed colors still match in light + dark mode
- [ ] Manual confirm date-picker default in ScrapeModal and SyncStatusModal at a non-UTC timezone near midnight

https://claude.ai/code/session_01PsMqDrMbbPZmCeTgvGvX9E

---
_Generated by [Claude Code](https://claude.ai/code/session_01PsMqDrMbbPZmCeTgvGvX9E)_