### PR TITLE
build(docker): exclude .wwebjs_auth runtime data from build context

### DIFF
--- a/app/.dockerignore
+++ b/app/.dockerignore
@@ -9,6 +9,14 @@ out
 build
 dist
 
+# Runtime data (persisted via named volumes at runtime; must not be baked into the image).
+# whatsapp-web.js writes its auth session and a Chromium cache here, which can grow to
+# tens/hundreds of MB. Without this, every build copies it into the context and the image
+# layer, bloating builds and intermittently failing the COPY on small disks
+# (e.g. "no space left on device" while copying .wwebjs_auth/.../Cache_Data).
+.wwebjs_auth
+.wwebjs_cache
+
 # Testing
 coverage
 


### PR DESCRIPTION
## What
Add `.wwebjs_auth` and `.wwebjs_cache` to `app/.dockerignore`.

## Why
`whatsapp-web.js` persists its auth session **and a Chromium cache** under `app/.wwebjs_auth`, which is mounted from a named volume (`whatsapp-data`) at runtime — so it should never be baked into the image.

When it isn't ignored, every `docker build` copies that directory into the build context and into the image layer. On small-disk self-hosted setups this:
- bloats the build context and image, and
- intermittently fails the build with `no space left on device` while copying the live cache, e.g.:

```
failed to solve: ResourceExhausted: failed to copy files: userspace copy failed:
write /app/.wwebjs_auth/session-nudlers-client/Default/Cache/Cache_Data/sqldb1-wal: no space left on device
```

Hit this on a self-hosted Proxmox LXC deployment. Excluding the runtime dir fixed the builds; the live session is unaffected since it lives in the named volume.

## Change
8 lines added to `app/.dockerignore` (no code changes).
