### PR TITLE
build(docker): also exclude .baileys_auth runtime data from build context

### DIFF
--- a/app/.dockerignore
+++ b/app/.dockerignore
@@ -16,6 +16,7 @@ dist
 # (e.g. "no space left on device" while copying .wwebjs_auth/.../Cache_Data).
 .wwebjs_auth
 .wwebjs_cache
+.baileys_auth
 
 # Testing
 coverage


### PR DESCRIPTION
Follow-up to #115: the codebase migrated from whatsapp-web.js to Baileys — auth state now lives at `.baileys_auth` (`app/utils/whatsapp-client.js:16`), which was gitignored and volume-mounted but not dockerignored. Same disk-exhaustion failure #115 fixed, one directory over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)