### PR TITLE
fix(scraper): drop --single-process/--no-zygote to stop Chromium launch crash

### DIFF
--- a/app/config/resource-config.js
+++ b/app/config/resource-config.js
@@ -137,8 +137,11 @@ const CHROME_FLAGS = {
     // Low resource flags - added for low mode
     lowResource: [
         // Process optimization (critical for limited resources)
-        '--single-process',
-        '--no-zygote',
+        // NOTE: --single-process / --no-zygote were removed — newer Chromium
+        // (bundled with puppeteer 24.43+) crashes on launch under them
+        // ("Failed to launch the browser process: Code: null" +
+        // "Cannot use V8 Proxy resolver in single process mode").
+        // The WhatsApp flags already omit --single-process for the same reason.
         '--disable-extensions',
         // Memory optimization
         '--disable-gl-drawing-for-tests',


### PR DESCRIPTION
## Problem

Scraping fails with:

```
Failed to launch the browser process: Code: null
... Cannot use V8 Proxy resolver in single process mode.
```

## Root cause

Commit `300c272` (Jul 6, dependency update) bumped `puppeteer-core` **24.40.0 → 24.43.1**, pulling a newer Chromium that crashes on launch under `--single-process` + `--no-zygote`. Those flags are added only in `low` resource mode (`resource-config.js` `lowResource`). The container runs effectively in low mode (compose default is `${RESOURCE_MODE:-low}` + baked `LOW_RESOURCES_MODE=true`), so the bump turned a previously-working launch into a hard crash.

The dbus / crashpad / cpufreq lines in the log are benign container noise, not the cause.

## Fix

Remove `--single-process` and `--no-zygote` from the `lowResource` Chrome flags. They give little real memory benefit and are the exact flags that crash newer Chromium. The WhatsApp flags already omit `--single-process` for the same reason — this brings the scraper path in line.

## Verification

- Generated low-mode args (`RESOURCE_MODE=low`) no longer contain the removed flags.
- `763/763` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)