### PR TITLE
fix(scraper): pin Chrome for Testing in Docker + isracard bot-detection fix (ibs 6.8.0)

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -70,14 +70,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libasound2 \
     libatk-bridge2.0-0 \
     libatk1.0-0 \
+    libatspi2.0-0 \
     libcairo2 \
     libcups2 \
     libdbus-1-3 \
+    libdrm2 \
     libexpat1 \
     libfontconfig1 \
     libgbm1 \
     libglib2.0-0 \
     libgtk-3-0 \
+    libxkbcommon0 \
     libnspr4 \
     libnss3 \
     libpango-1.0-0 \
@@ -113,7 +116,10 @@ RUN ARCH="$(dpkg --print-architecture)" \
     else \
     apt-get update && apt-get install -y --no-install-recommends chromium \
     && rm -rf /var/lib/apt/lists/*; \
-    fi
+    fi \
+    # Build-time assertion: fail the build (instead of failing at runtime in production)
+    # if /usr/bin/chromium is a dangling symlink or the browser can't execute.
+    && /usr/bin/chromium --version
 
 # 2. Setup non-root user for running the app
 # Handle case where GID/UID might already exist in base image

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -41,6 +41,15 @@ FROM node:22-bookworm-slim AS runner
 
 WORKDIR /app
 
+# Chrome for Testing version — MUST match the browser pinned by our puppeteer version
+# (see node_modules/puppeteer-core/lib/cjs/puppeteer/revisions.js for puppeteer 24.40.0).
+# On amd64 we use Google's pinned build instead of Debian's `chromium` package because the
+# Debian build drifts to a new version on every image rebuild, and newer builds crash on
+# launch (SIGTRAP / "Failed to launch the browser process: Code: null") in some virtualized
+# environments (see #120). Google does not publish linux/arm64 builds, so arm64 keeps the
+# Debian package (which does not exhibit the crash).
+ARG CHROME_VERSION=146.0.7680.153
+
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1 \
     PORT=3000 \
@@ -52,10 +61,9 @@ ENV NODE_ENV=production \
     # Reduce logging verbosity for NAS
     LOG_LEVEL=warn
 
-# 1. Install minimal Chromium and its dependencies + Xvfb + Tini + gosu (for privilege dropping)
-# We use Chromium from the Debian repo to keep the image small
+# 1. Install Chromium runtime dependencies + Xvfb + Tini + gosu (for privilege dropping)
+# (the browser itself is Google's pinned Chrome for Testing, installed in step 1b)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    chromium \
     fonts-liberation \
     fonts-noto-core \
     fonts-noto-ui-core \
@@ -92,6 +100,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tini \
     gosu \
     && rm -rf /var/lib/apt/lists/*
+
+# 1b. Install the browser behind /usr/bin/chromium (see CHROME_VERSION comment above):
+#     amd64 → Google's pinned Chrome for Testing; arm64 → Debian chromium package
+RUN ARCH="$(dpkg --print-architecture)" \
+    && if [ "$ARCH" = "amd64" ]; then \
+    apt-get update && apt-get install -y --no-install-recommends unzip \
+    && npx -y @puppeteer/browsers install chrome@${CHROME_VERSION} --path /opt/chrome \
+    && ln -sf "/opt/chrome/chrome/linux-${CHROME_VERSION}/chrome-linux64/chrome" /usr/bin/chromium \
+    && chmod -R a+rX /opt/chrome \
+    && apt-get purge -y unzip && apt-get autoremove -y && rm -rf /var/lib/apt/lists/* /root/.npm; \
+    else \
+    apt-get update && apt-get install -y --no-install-recommends chromium \
+    && rm -rf /var/lib/apt/lists/*; \
+    fi
 
 # 2. Setup non-root user for running the app
 # Handle case where GID/UID might already exist in base image

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -26,7 +26,7 @@
         "date-fns": "^4.2.1",
         "dotenv": "^17.4.2",
         "i18next": "^26.2.0",
-        "israeli-bank-scrapers": "^6.7.4",
+        "israeli-bank-scrapers": "^6.8.0",
         "next": "^16.2.6",
         "next-auth": "^4.24.14",
         "node-cron": "^4.2.1",
@@ -10135,9 +10135,9 @@
       "license": "ISC"
     },
     "node_modules/israeli-bank-scrapers": {
-      "version": "6.7.9",
-      "resolved": "https://registry.npmjs.org/israeli-bank-scrapers/-/israeli-bank-scrapers-6.7.9.tgz",
-      "integrity": "sha512-kdRuG2gjCNXsUgk58WVISnZBNyoG8pX3764SbQhKfB/2YVFq+RgQsUJCK4Rv/Y+UgVmZnzcC/lQpxiTPe+S0iw==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/israeli-bank-scrapers/-/israeli-bank-scrapers-6.8.0.tgz",
+      "integrity": "sha512-zoLgVpvX/m1gb4vO7EegDrV7tzktIkdQMyXPZhVPDKT69LCwpP/oiuEwclWZfLWBBKpOx6jCwYg0Z3Ymaj1GlA==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.2",

--- a/app/package.json
+++ b/app/package.json
@@ -36,7 +36,7 @@
     "date-fns": "^4.2.1",
     "dotenv": "^17.4.2",
     "i18next": "^26.2.0",
-    "israeli-bank-scrapers": "^6.7.4",
+    "israeli-bank-scrapers": "^6.8.0",
     "next": "^16.2.6",
     "next-auth": "^4.24.14",
     "node-cron": "^4.2.1",

--- a/app/pages/api/utils/scraperErrors.js
+++ b/app/pages/api/utils/scraperErrors.js
@@ -36,13 +36,17 @@ const RETRYABLE = {
   UNKNOWN: true,
 };
 
+// Keys are the israeli-bank-scrapers ScraperErrorTypes enum VALUES (UPPER_SNAKE —
+// see node_modules/israeli-bank-scrapers/lib/scrapers/errors.js), which is what
+// scrape results carry in `errorType`.
 const LIB_ERROR_TYPE_MAP = {
-  invalidPassword: ScrapeErrorTypes.INVALID_CREDENTIALS,
-  changePassword: ScrapeErrorTypes.CHANGE_PASSWORD_REQUIRED,
-  accountBlocked: ScrapeErrorTypes.ACCOUNT_BLOCKED,
-  timeout: ScrapeErrorTypes.TIMEOUT,
-  twoFactorRetrieverMissing: ScrapeErrorTypes.OTP_REQUIRED,
-  generic: ScrapeErrorTypes.UNKNOWN,
+  INVALID_PASSWORD: ScrapeErrorTypes.INVALID_CREDENTIALS,
+  CHANGE_PASSWORD: ScrapeErrorTypes.CHANGE_PASSWORD_REQUIRED,
+  ACCOUNT_BLOCKED: ScrapeErrorTypes.ACCOUNT_BLOCKED,
+  TIMEOUT: ScrapeErrorTypes.TIMEOUT,
+  TWO_FACTOR_RETRIEVER_MISSING: ScrapeErrorTypes.OTP_REQUIRED,
+  GENERIC: ScrapeErrorTypes.UNKNOWN,
+  GENERAL_ERROR: ScrapeErrorTypes.UNKNOWN,
 };
 
 function classifyByMessage(rawMessage) {

--- a/app/pages/api/utils/scraperUtils.js
+++ b/app/pages/api/utils/scraperUtils.js
@@ -1138,7 +1138,7 @@ export async function runScraper(client, scraperOptions, credentials, onProgress
     // Race between the scrape process and the global timeout
     const result = await Promise.race([scrapePromise, timeoutPromise]);
     clearTimeout(timeoutId);
-    logger.info({ success: result?.success }, '[Scraper] Base scrape completed');
+    logger.info({ success: result?.success, errorType: result?.errorType, errorMessage: result?.errorMessage }, '[Scraper] Base scrape completed');
 
     if (result.success && result.accounts && !Array.isArray(result.accounts)) {
       result.accounts = [];

--- a/app/tests/scraperErrors.test.ts
+++ b/app/tests/scraperErrors.test.ts
@@ -8,20 +8,33 @@ import { vi } from 'vitest';
 import { classifyScrapeError, ScrapeErrorTypes } from '../pages/api/utils/scraperErrors.js';
 
 describe('classifyScrapeError', () => {
-    it('maps library errorType invalidPassword to INVALID_CREDENTIALS', () => {
+    // errorType values below are the israeli-bank-scrapers ScraperErrorTypes enum
+    // VALUES (UPPER_SNAKE), i.e. what scrape results actually carry — see
+    // node_modules/israeli-bank-scrapers/lib/scrapers/errors.js.
+    it('maps library errorType INVALID_PASSWORD to INVALID_CREDENTIALS', () => {
         const result = classifyScrapeError({
-            libResult: { success: false, errorType: 'invalidPassword', errorMessage: 'wrong password' }
+            libResult: { success: false, errorType: 'INVALID_PASSWORD', errorMessage: 'wrong password' }
         });
         expect(result.type).toBe(ScrapeErrorTypes.INVALID_CREDENTIALS);
         expect(result.retryable).toBe(false);
     });
 
-    it('maps library errorType timeout to TIMEOUT (retryable)', () => {
+    it('maps library errorType TIMEOUT to TIMEOUT (retryable)', () => {
         const result = classifyScrapeError({
-            libResult: { success: false, errorType: 'timeout', errorMessage: 'timed out' }
+            libResult: { success: false, errorType: 'TIMEOUT', errorMessage: 'timed out' }
         });
         expect(result.type).toBe(ScrapeErrorTypes.TIMEOUT);
         expect(result.retryable).toBe(true);
+    });
+
+    it('maps library errorType CHANGE_PASSWORD to CHANGE_PASSWORD_REQUIRED even with empty errorMessage', () => {
+        // Regression: the lib emits UPPER_SNAKE errorType values with often-empty
+        // errorMessage; classification must not depend on message heuristics here.
+        const result = classifyScrapeError({
+            libResult: { success: false, errorType: 'CHANGE_PASSWORD', errorMessage: '' }
+        });
+        expect(result.type).toBe(ScrapeErrorTypes.CHANGE_PASSWORD_REQUIRED);
+        expect(result.retryable).toBe(false);
     });
 
     it('classifies OneZero ErrorLoginFailed body as INVALID_CREDENTIALS', () => {


### PR DESCRIPTION
## Problem

Two independent failures broke scraping:

1. **Isracard/Amex logins fail** with `unknown error during login` — Isracard rolled out bot detection (`detector-dom.min.js`). Fixed upstream in israeli-bank-scrapers **6.8.0** ("fix(isracard): workaround for bot detection", #1135).

2. **Browser won't launch at all on the production homelab** (`Failed to launch the browser process: Code: null`, SIGTRAP). Root cause: the Dockerfile installs Debian's `chromium` package, whose version drifts on every image rebuild. Debian chromium **150.x crashes on launch in KVM/QEMU environments**. Verified empirically on the affected host: Debian chromium 150 traps instantly, while Google's Chrome for Testing 146 runs fine in the same container.

## Changes

- Bump `israeli-bank-scrapers` 6.7.9 → **6.8.0**
- **amd64**: install Google's pinned **Chrome for Testing 146.0.7680.153** (matching the puppeteer 24.40.0 pin) via `@puppeteer/browsers` instead of Debian's `chromium`. Browser version is now reproducible across rebuilds.
- **arm64**: keep Debian chromium (Google publishes no linux/arm64 CfT builds; the arm build doesn't exhibit the crash). Both arches expose the browser at `/usr/bin/chromium`, so `PUPPETEER_EXECUTABLE_PATH` is arch-independent.
- Log `errorType`/`errorMessage` when a scrape completes unsuccessfully (failures like `CHANGE_PASSWORD` were previously reported as a generic "Scraper failed").

## Verification

- ✅ 763/763 tests pass
- ✅ arm64 image built on macOS: Debian chromium launches, app healthy
- ✅ amd64 image built **natively on the affected homelab host**: pinned Chrome 146 launches and renders
- ✅ End-to-end Isracard smoke on the homelab (dummy credentials): browser → isracard.co.il → bot detection passed → `ValidateIdData` OK → clean `INVALID_PASSWORD` rejection (exactly the expected outcome for wrong credentials)
- ✅ Real-credential Isracard scrape verified locally on macOS after the 6.8.0 bump (246 fetched / 199 saved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)