### PR TITLE
Fix legacy Bank Hapoalim vendor alias

### DIFF
--- a/app/pages/api/scrapers/sync-all-stream.js
+++ b/app/pages/api/scrapers/sync-all-stream.js
@@ -20,7 +20,7 @@ import {
     loadCategoryMappings,
     checkScraperConcurrency,
 } from '../utils/scraperUtils';
-import { BANK_VENDORS } from '../../../utils/constants';
+import { BANK_VENDORS, normalizeVendor } from '../../../utils/constants';
 import { VaultLockedError } from '../utils/encryption';
 
 // Helper to send SSE messages to the local client
@@ -85,7 +85,7 @@ export default async function handler(req, res) {
 
         const accounts = accountsResult.rows.map(row => ({
             id: row.id,
-            vendor: row.vendor,
+            vendor: normalizeVendor(row.vendor),
             nickname: row.nickname || row.vendor,
             credentials: {
                 username: row.username ? decrypt(row.username) : null,

--- a/app/scripts/background-sync.js
+++ b/app/scripts/background-sync.js
@@ -14,7 +14,7 @@ import {
     getScraperTimeout,
     checkScraperConcurrency
 } from '../pages/api/utils/scraperUtils.js';
-import { APP_SETTINGS_KEYS, FETCH_SETTING_SQL } from '../utils/constants.js';
+import { APP_SETTINGS_KEYS, FETCH_SETTING_SQL, normalizeVendor } from '../utils/constants.js';
 
 
 // Standalone DB connection for the script
@@ -73,7 +73,7 @@ async function runBackgroundSync() {
         const fetchCategoriesSetting = await getFetchCategoriesSetting(client);
 
         for (const row of accountsResult.rows) {
-            const companyId = row.vendor;
+            const companyId = normalizeVendor(row.vendor);
 
             logger.info({ vendor: companyId, nickname: row.nickname }, '[Background Sync] Syncing account');
 

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -6,6 +6,9 @@ export const CREDIT_CARD_VENDORS = ['visaCal', 'max', 'isracard', 'amex'];
 // Bank vendors (standard format: id, password, num)
 export const STANDARD_BANK_VENDORS = ['hapoalim', 'poalim', 'leumi', 'mizrahi', 'discount', 'yahav', 'union', 'fibi', 'jerusalem', 'onezero', 'pepper'];
 
+// Compatibility with older records that used "poalim" for Bank Hapoalim.
+export const normalizeVendor = (vendor) => vendor === 'poalim' ? 'hapoalim' : vendor;
+
 // Beinleumi Group banks (special format: username, password only)
 export const BEINLEUMI_GROUP_VENDORS = ['otsarHahayal', 'otsar_hahayal', 'beinleumi', 'massad', 'pagi'];
 


### PR DESCRIPTION
## Summary
- normalize legacy `poalim` account vendor values to `hapoalim`
- apply normalization to interactive and background sync paths

This prevents existing Bank Hapoalim accounts saved with the old vendor alias from failing with `unknown company id poalim`.

## Validation
- Targeted Vitest could not run because app dependencies (`vitest`) are not installed in the checkout.